### PR TITLE
Allow setting tintColor of iOS PageView component

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ const styles = StyleSheet.create({
 |`orientation: Orientation`|Set `horizontal` or `vertical` scrolling orientation (it does **not** work dynamically)|both
 |`transitionStyle: TransitionStyle`|Use `scroll` or `curl` to change transition style (it does **not** work dynamically)|iOS
 |`showPageIndicator: boolean`|Shows the dots indicator at the bottom of the view|iOS
+|`currentPageIndicatorTintColor: string`|A hexadecimal representation of the color for the active tab of the page indicator|iOS
+|`pageIndicatorTintColor: string`|A hexadecimal representation of the color for the inactive tabs of the page indicator|iOS
 
 ## Preview
 

--- a/example/ViewPagerExample.js
+++ b/example/ViewPagerExample.js
@@ -133,6 +133,8 @@ export default class ViewPagerExample extends React.Component<*, State> {
           // Lib does not support dynamically transitionStyle change
           transitionStyle="scroll"
           showPageIndicator={dotsVisible}
+          currentPageIndicatorTintColor={'#0000FF'}
+          pageIndicatorTintColor={'#FF0000'}
           ref={this.viewPager}>
           {pages.map(p => this.renderPage(p))}
         </ViewPager>

--- a/ios/ReactNativePageView.h
+++ b/ios/ReactNativePageView.h
@@ -14,6 +14,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) RCTEventDispatcher *eventDispatcher;
 
 @property(nonatomic, strong) NSMutableArray<UIViewController *> *childrenViewControllers;
+@property(nonatomic) UIColor *currentPageIndicatorTintColor;
+@property(nonatomic) UIColor *pageIndicatorTintColor;
 @property(nonatomic) NSInteger initialPage;
 @property(nonatomic) NSInteger currentIndex;
 @property(nonatomic) NSInteger pageMargin;

--- a/ios/ReactNativePageView.m
+++ b/ios/ReactNativePageView.m
@@ -48,7 +48,6 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
     return _coalescingKey;
 }
 
-
 - (BOOL)canCoalesce
 {
     return NO;
@@ -483,9 +482,9 @@ willTransitionToViewControllers:
     UIPageControl *pageControl = [[UIPageControl alloc] init];
     pageControl.numberOfPages = _childrenViewControllers.count;
     pageControl.currentPage = _initialPage;
-    pageControl.tintColor = UIColor.blackColor;
-    pageControl.pageIndicatorTintColor = UIColor.whiteColor;
-    pageControl.currentPageIndicatorTintColor = UIColor.blackColor;
+    pageControl.tintColor = _currentPageIndicatorTintColor;
+    pageControl.pageIndicatorTintColor = _pageIndicatorTintColor;
+    pageControl.currentPageIndicatorTintColor = _currentPageIndicatorTintColor;
     [pageControl addTarget:self
                     action:@selector(pageControlValueChanged:)
           forControlEvents:UIControlEventValueChanged];

--- a/ios/ReactViewPagerManager.m
+++ b/ios/ReactViewPagerManager.m
@@ -9,6 +9,8 @@ RCT_EXPORT_MODULE(RNCViewPager)
 
 RCT_EXPORT_VIEW_PROPERTY(initialPage, NSInteger)
 RCT_EXPORT_VIEW_PROPERTY(pageMargin, NSInteger)
+RCT_EXPORT_VIEW_PROPERTY(currentPageIndicatorTintColor, UIColor)
+RCT_EXPORT_VIEW_PROPERTY(pageIndicatorTintColor, UIColor)
 
 RCT_EXPORT_VIEW_PROPERTY(transitionStyle, UIPageViewControllerTransitionStyle)
 RCT_EXPORT_VIEW_PROPERTY(orientation, UIPageViewControllerNavigationOrientation)

--- a/js/types.js
+++ b/js/types.js
@@ -101,4 +101,6 @@ export type ViewPagerProps = $ReadOnly<{|
   orientation?: Orientation,
   transitionStyle?: TransitionStyle,
   showPageIndicator?: boolean,
+  currentPageIndicatorTintColor?: string,
+  pageIndicatorTintColor?: string,
 |}>;


### PR DESCRIPTION
# Summary
* Allows configuration of the tintColor of the PageView component on iOS
* See https://github.com/react-native-community/react-native-viewpager/issues/98

## Test Plan

I verified it works by installing it locally on a project that I'm working on. Included are screenshots of the configuration and end result

![Simulator Screen Shot - iPhone 11 - 2019-12-12 at 10 16 25](https://user-images.githubusercontent.com/805610/70734002-a37aea80-1cc8-11ea-8638-3fe90cd5557f.png)
![Screen Shot 2019-12-12 at 10 16 43 AM](https://user-images.githubusercontent.com/805610/70733963-8d6d2a00-1cc8-11ea-908d-050b568dc030.png)

### What's required for testing (prerequisites)?

An embedded ViewPager in a react-native app

### What are the steps to reproduce (after prerequisites)?

Include the properties 
```
currentPageIndicatorTintColor={'#00FFFF'}
pageIndicatorTintColor={'#FF0000'}
```
on the view pager, reload, verify that the active and inactive tint colors have been changed (iOS only)

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
  - I don't see a `CHANGELOG.md` in the repository. I'm happy to add this to the appropriate place.
- [x] I updated the typed files (TS and Flow)
- [x] I added a sample use of the API in the example project (`example/App.js`)
