### PR TITLE
fix(ios): onPageSelected event

### DIFF
--- a/ios/ReactNativePageView.h
+++ b/ios/ReactNativePageView.h
@@ -10,6 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher;
 
 @property(nonatomic) NSInteger initialPage;
+@property(nonatomic) NSInteger previousIndex;
 @property(nonatomic) NSInteger currentIndex;
 @property(nonatomic) NSInteger pageMargin;
 @property(nonatomic, readonly) BOOL scrollEnabled;

--- a/ios/ReactNativePageView.m
+++ b/ios/ReactNativePageView.m
@@ -36,6 +36,7 @@
     if (self = [super init]) {
         _scrollEnabled = YES;
         _pageMargin = 0;
+        _previousIndex = -1;
         _transitionStyle = UIPageViewControllerTransitionStyleScroll;
         _orientation = UIPageViewControllerNavigationOrientationHorizontal;
         _currentIndex = 0;
@@ -173,7 +174,10 @@
         weakSelf.currentView = controller.view;
         
         if (weakSelf.eventDispatcher) {
-            [weakSelf.eventDispatcher sendEvent:[[RCTOnPageSelected alloc] initWithReactTag:weakSelf.reactTag position:@(index) coalescingKey:coalescingKey]];
+            if(_previousIndex != _currentIndex){
+                [weakSelf.eventDispatcher sendEvent:[[RCTOnPageSelected alloc] initWithReactTag:weakSelf.reactTag position:@(index) coalescingKey:coalescingKey]];
+            }
+            _previousIndex = _currentIndex;
         }
         
     }];
@@ -280,7 +284,7 @@
         NSUInteger currentIndex = [self.reactSubviews indexOfObject:currentVC.view];
         
         self.currentIndex = currentIndex;
-        
+        self.previousIndex = currentIndex - 1;
         self.currentView = currentVC.view;
         self.reactPageIndicatorView.currentPage = currentIndex;
         


### PR DESCRIPTION
# Summary

fix onPageSelected event

Closes #297 

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

- [X] I have tested this on a device and a simulator

