### PR TITLE
Lazy pager (js side)

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -4,6 +4,7 @@ import { NavigationContainer, useNavigation } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 import { BasicPagerViewExample } from './BasicPagerViewExample';
 import { KeyboardExample } from './KeyboardExample';
+import { LazyPagerViewExample } from './LazyPagerViewExample';
 import { OnPageScrollExample } from './OnPageScrollExample';
 import { OnPageSelectedExample } from './OnPageSelectedExample';
 import { ScrollablePagerViewExample } from './ScrollablePagerViewExample';
@@ -14,6 +15,7 @@ import PaginationDotsExample from './PaginationDotsExample';
 const examples = [
   { component: BasicPagerViewExample, name: 'Basic Example' },
   { component: KeyboardExample, name: 'Keyboard Example' },
+  { component: LazyPagerViewExample, name: 'Lazy Render Example' },
   { component: OnPageScrollExample, name: 'OnPageScroll Example' },
   { component: OnPageSelectedExample, name: 'OnPageSelected Example' },
   { component: HeadphonesCarouselExample, name: 'Headphones Carousel Example' },

--- a/example/src/BasicPagerViewExample.tsx
+++ b/example/src/BasicPagerViewExample.tsx
@@ -10,7 +10,7 @@ import { useNavigationPanel } from './hook/useNavigationPanel';
 const AnimatedPagerView = Animated.createAnimatedComponent(PagerView);
 
 export function BasicPagerViewExample() {
-  const { ref, ...navigationPanel } = useNavigationPanel();
+  const { ref, ...navigationPanel } = useNavigationPanel<PagerView>();
 
   return (
     <SafeAreaView style={styles.container}>

--- a/example/src/BasicPagerViewExample.tsx
+++ b/example/src/BasicPagerViewExample.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import { StyleSheet, View, SafeAreaView, Animated, Text } from 'react-native';
 
-import PagerView from 'react-native-pager-view';
+import { PagerView } from 'react-native-pager-view';
 
 import { LikeCount } from './component/LikeCount';
 import { NavigationPanel } from './component/NavigationPanel';

--- a/example/src/HeadphonesCarouselExample.tsx
+++ b/example/src/HeadphonesCarouselExample.tsx
@@ -17,7 +17,7 @@ import {
   ImageRequireSource,
 } from 'react-native';
 import type { PagerViewOnPageScrollEventData } from 'src/types';
-import PagerView from 'react-native-pager-view';
+import { PagerView } from 'react-native-pager-view';
 
 const data = [
   {

--- a/example/src/KeyboardExample.tsx
+++ b/example/src/KeyboardExample.tsx
@@ -11,7 +11,7 @@ import {
   Animated,
 } from 'react-native';
 import { Colors } from 'react-native/Libraries/NewAppScreen';
-import PagerView from 'react-native-pager-view';
+import { PagerView } from 'react-native-pager-view';
 import { logoUrl } from './utils';
 
 import { NavigationPanel } from './component/NavigationPanel';

--- a/example/src/KeyboardExample.tsx
+++ b/example/src/KeyboardExample.tsx
@@ -37,7 +37,7 @@ const Page = ({ title, description, onPress, buttonTitle }: PageProps) => {
 const AnimatedPagerView = Animated.createAnimatedComponent(PagerView);
 
 export function KeyboardExample() {
-  const { ref, ...navigationPanel } = useNavigationPanel(2);
+  const { ref, ...navigationPanel } = useNavigationPanel<PagerView>(2);
   const { setPage } = navigationPanel;
   return (
     <SafeAreaView style={styles.flex}>

--- a/example/src/LazyPagerViewExample.tsx
+++ b/example/src/LazyPagerViewExample.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { Image, StyleSheet, View, SafeAreaView, Animated } from 'react-native';
+
+import { LazyPagerView } from 'react-native-pager-view';
+
+import { LikeCount } from './component/LikeCount';
+import { NavigationPanel } from './component/NavigationPanel';
+import { useNavigationPanel } from './hook/useNavigationPanel';
+import type { CreatePage } from './utils';
+
+const AnimatedPagerView = Animated.createAnimatedComponent(LazyPagerView);
+
+function keyExtractor(page: CreatePage) {
+  return `${page.key}`;
+}
+
+function renderItem({ item }: { item: CreatePage }) {
+  return (
+    <View style={item.style}>
+      <Image style={styles.image} source={item.imgSource} />
+      <LikeCount />
+    </View>
+  );
+}
+
+export function LazyPagerViewExample() {
+  const { ref, ...navigationPanel } = useNavigationPanel<
+    LazyPagerView<unknown>
+  >();
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <AnimatedPagerView
+        ref={ref}
+        style={styles.PagerView}
+        initialPage={0}
+        overdrag={navigationPanel.overdragEnabled}
+        scrollEnabled={navigationPanel.scrollEnabled}
+        onPageScroll={navigationPanel.onPageScroll}
+        onPageSelected={navigationPanel.onPageSelected}
+        onPageScrollStateChanged={navigationPanel.onPageScrollStateChanged}
+        pageMargin={10}
+        // Lib does not support dynamically orientation change
+        orientation="horizontal"
+        // Lib does not support dynamically transitionStyle change
+        transitionStyle="scroll"
+        showPageIndicator={navigationPanel.dotsEnabled}
+        data={navigationPanel.pages}
+        keyExtractor={keyExtractor}
+        renderItem={renderItem}
+      />
+      <NavigationPanel {...navigationPanel} />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: 'white',
+  },
+  image: {
+    width: 300,
+    height: 200,
+    padding: 20,
+  },
+  PagerView: {
+    flex: 1,
+  },
+});

--- a/example/src/OnPageScrollExample.tsx
+++ b/example/src/OnPageScrollExample.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { StyleSheet, Text, View, SafeAreaView, Animated } from 'react-native';
-import PagerView from 'react-native-pager-view';
+import { PagerView } from 'react-native-pager-view';
 import { ScrollView, TouchableOpacity } from 'react-native-gesture-handler';
 import { ProgressBar } from './component/ProgressBar';
 import { useNavigationPanel } from './hook/useNavigationPanel';

--- a/example/src/OnPageScrollExample.tsx
+++ b/example/src/OnPageScrollExample.tsx
@@ -9,7 +9,7 @@ import { NavigationPanel } from './component/NavigationPanel';
 const AnimatedPagerView = Animated.createAnimatedComponent(PagerView);
 
 export function OnPageScrollExample() {
-  const { ref, ...navigationPanel } = useNavigationPanel(5);
+  const { ref, ...navigationPanel } = useNavigationPanel<PagerView>(5);
   const { activePage, setPage, progress, pages } = navigationPanel;
 
   return (

--- a/example/src/OnPageSelectedExample.tsx
+++ b/example/src/OnPageSelectedExample.tsx
@@ -9,7 +9,7 @@ import {
   Animated,
 } from 'react-native';
 
-import PagerView from 'react-native-pager-view';
+import { PagerView } from 'react-native-pager-view';
 import { NavigationPanel } from './component/NavigationPanel';
 import { useNavigationPanel } from './hook/useNavigationPanel';
 

--- a/example/src/OnPageSelectedExample.tsx
+++ b/example/src/OnPageSelectedExample.tsx
@@ -19,7 +19,10 @@ export const OnPageSelectedExample = () => {
   const callback = React.useCallback((position: number) => {
     Alert.alert('Hey', `You are on ${position + 1} page`);
   }, []);
-  const { ref, ...navigationPanel } = useNavigationPanel(10, callback);
+  const { ref, ...navigationPanel } = useNavigationPanel<PagerView>(
+    10,
+    callback
+  );
 
   return (
     <SafeAreaView style={styles.flex}>

--- a/example/src/PaginationDotsExample.tsx
+++ b/example/src/PaginationDotsExample.tsx
@@ -7,7 +7,8 @@ import {
   Animated,
   Dimensions,
 } from 'react-native';
-import PagerView, {
+import {
+  PagerView,
   PagerViewOnPageScrollEventData,
 } from 'react-native-pager-view';
 

--- a/example/src/ScrollViewInsideExample.tsx
+++ b/example/src/ScrollViewInsideExample.tsx
@@ -1,4 +1,4 @@
-import PagerView from 'react-native-pager-view';
+import { PagerView } from 'react-native-pager-view';
 import React from 'react';
 import { useState } from 'react';
 import { View, StyleSheet, Button, ScrollView, Animated } from 'react-native';

--- a/example/src/ScrollablePagerViewExample.tsx
+++ b/example/src/ScrollablePagerViewExample.tsx
@@ -1,4 +1,4 @@
-import PagerView from 'react-native-pager-view';
+import { PagerView } from 'react-native-pager-view';
 import React from 'react';
 import { ScrollView, View, Image, StyleSheet, Animated } from 'react-native';
 import { NavigationPanel } from './component/NavigationPanel';

--- a/example/src/ScrollablePagerViewExample.tsx
+++ b/example/src/ScrollablePagerViewExample.tsx
@@ -9,7 +9,7 @@ const HEIGHT = 300;
 const AnimatedPagerView = Animated.createAnimatedComponent(PagerView);
 
 export const ScrollablePagerViewExample = (): JSX.Element => {
-  const { ref, ...navigationPanel } = useNavigationPanel();
+  const { ref, ...navigationPanel } = useNavigationPanel<PagerView>();
 
   return (
     <>

--- a/example/src/hook/useNavigationPanel.ts
+++ b/example/src/hook/useNavigationPanel.ts
@@ -1,5 +1,5 @@
 import type {
-  PagerView,
+  Pageable,
   PageScrollStateChangedNativeEvent,
   PagerViewOnPageScrollEventData,
   PagerViewOnPageSelectedEventData,
@@ -19,11 +19,11 @@ export interface EventLog {
 const getBasePages = (pages: number) =>
   new Array(pages).fill('').map((_v, index) => createPage(index));
 
-export function useNavigationPanel(
+export function useNavigationPanel<T extends Pageable>(
   pagesAmount: number = 10,
   onPageSelectedCallback: (position: number) => void = () => {}
 ) {
-  const ref = useRef<PagerView>(null);
+  const ref = useRef<T>(null);
   const [pages, setPages] = useState<CreatePage[]>(
     useMemo(() => getBasePages(pagesAmount), [pagesAmount])
   );

--- a/example/src/hook/useNavigationPanel.ts
+++ b/example/src/hook/useNavigationPanel.ts
@@ -1,5 +1,5 @@
 import type {
-  default as PagerView,
+  PagerView,
   PageScrollStateChangedNativeEvent,
   PagerViewOnPageScrollEventData,
   PagerViewOnPageSelectedEventData,

--- a/example/src/utils.ts
+++ b/example/src/utils.ts
@@ -11,7 +11,7 @@ export const IMAGE_URIS = [
 ];
 export const thumbsUp = '\uD83D\uDC4D';
 export const logoUrl =
-  'https://raw.githubusercontent.com/react-native-community/react-native-viewpager/master/docs/viewpager-logo.png';
+  'https://raw.githubusercontent.com/callstack/react-native-pager-view/master/img/viewpager-logo.png';
 
 export type CreatePage = {
   key: number;

--- a/example/src/utils.ts
+++ b/example/src/utils.ts
@@ -25,6 +25,7 @@ export const createPage = (key: number): CreatePage => {
     style: {
       backgroundColor: BGCOLOR[key % BGCOLOR.length],
       alignItems: 'center',
+      flex: 1,
       padding: 20,
     },
     imgSource: { uri: IMAGE_URIS[key % BGCOLOR.length] },

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "prettier": "^2.0.5",
     "react": "16.13.1",
     "react-native": "0.63.4",
-    "react-native-builder-bob": "^",
+    "react-native-builder-bob": "^0.18.1",
     "release-it": "^14.2.2",
     "typescript": "^4.1.3"
   },

--- a/src/LazyPagerView.tsx
+++ b/src/LazyPagerView.tsx
@@ -222,16 +222,20 @@ class LazyPagerViewImpl<ItemT> extends React.Component<
   };
 
   private onPageSelected = (event: PagerViewOnPageSelectedEvent) => {
+    // Queue renders for next needed pages (if not already available).
     const currentPage = event.nativeEvent.position;
-    this.setState((prevState) =>
-      this.computeRenderWindow({
-        buffer: this.props.buffer,
-        currentPage,
-        maxRenderWindow: this.props.maxRenderWindow,
-        offset: prevState.offset,
-        windowLength: prevState.windowLength,
-      })
-    );
+    requestAnimationFrame(() => {
+      this.setState((prevState) =>
+        this.computeRenderWindow({
+          buffer: this.props.buffer,
+          currentPage,
+          maxRenderWindow: this.props.maxRenderWindow,
+          offset: prevState.offset,
+          windowLength: prevState.windowLength,
+        })
+      );
+    });
+
     this.props.onPageSelected?.(event);
   };
 

--- a/src/LazyPagerView.tsx
+++ b/src/LazyPagerView.tsx
@@ -1,0 +1,227 @@
+import React from 'react';
+import {
+  findNodeHandle,
+  Keyboard,
+  StyleSheet,
+  UIManager,
+  View,
+} from 'react-native';
+
+import { getViewManagerConfig, PagerViewViewManager } from './PagerViewNative';
+import type {
+  LazyPagerViewProps,
+  PagerViewOnPageScrollEvent,
+  PagerViewOnPageSelectedEvent,
+  PageScrollStateChangedNativeEvent,
+} from './types';
+
+type LazyPagerViewState = { offset: number; windowLength: number };
+
+type RenderWindowData = {
+  buffer: number | undefined;
+  currentPage: number;
+  maxRenderWindow: number | undefined;
+  offset: number;
+  windowLength: number;
+};
+
+/**
+ * PagerView implementation that renders pages on demand.
+ *
+ * Note: under current implementation, pages are never unloaded. Also, all
+ * pages before the visible page are rendered.
+ */
+export class LazyPagerView<ItemT> extends React.PureComponent<
+  LazyPagerViewProps<ItemT>,
+  LazyPagerViewState
+> {
+  private isScrolling = false;
+
+  constructor(props: LazyPagerViewProps<ItemT>) {
+    super(props);
+    this.state = this.computeRenderWindow({
+      buffer: props.buffer,
+      currentPage: props.initialPage ?? 0,
+      maxRenderWindow: props.maxRenderWindow,
+      offset: 0,
+      windowLength: 0,
+    });
+  }
+
+  componentDidMount() {
+    const initialPage = this.props.initialPage;
+    if (initialPage != null && initialPage > 0) {
+      // Send command directly; render window already contains destination.
+      UIManager.dispatchViewManagerCommand(
+        findNodeHandle(this),
+        getViewManagerConfig().Commands.setPageWithoutAnimation,
+        [initialPage]
+      );
+    }
+  }
+
+  /**
+   * A helper function to scroll to a specific page in the PagerView.
+   * Default to animated transition between pages.
+   */
+  setPage(page: number, animated = true) {
+    if (page < 0 || page >= this.props.data.length) {
+      return;
+    }
+
+    // Start rendering the destination.
+    this.setState((prevState) =>
+      this.computeRenderWindow({
+        buffer: this.props.buffer,
+        currentPage: page,
+        maxRenderWindow: this.props.maxRenderWindow,
+        offset: prevState.offset,
+        windowLength: prevState.windowLength,
+      })
+    );
+    // Send paging command.
+    requestAnimationFrame(() => {
+      UIManager.dispatchViewManagerCommand(
+        findNodeHandle(this),
+        animated
+          ? getViewManagerConfig().Commands.setPage
+          : getViewManagerConfig().Commands.setPageWithoutAnimation,
+        [page]
+      );
+    });
+  }
+
+  /**
+   * A helper function to scroll to a specific page in the PagerView.
+   * The transition between pages will *not* be animated.
+   */
+  setPageWithoutAnimation(page: number) {
+    this.setPage(page, false);
+  }
+
+  /**
+   * A helper function to enable/disable scroll imperatively.
+   * The recommended way is using the scrollEnabled prop, however, there might
+   * be a case where an imperative solution is more useful (e.g. for not
+   * blocking an animation)
+   */
+  setScrollEnabled(scrollEnabled: boolean) {
+    UIManager.dispatchViewManagerCommand(
+      findNodeHandle(this),
+      getViewManagerConfig().Commands.setScrollEnabled,
+      [scrollEnabled]
+    );
+  }
+
+  /**
+   * Compute desired render window size.
+   *
+   * Returns `offset` and `windowLength` unmodified, unless in conflict with
+   * restrictions from `buffer` or `maxRenderWindow`.
+   *
+   * Currently will always yield `offset` of `0`.
+   */
+  private computeRenderWindow(data: RenderWindowData): LazyPagerViewState {
+    if (data.maxRenderWindow != null && data.maxRenderWindow !== 0) {
+      console.warn('`maxRenderWindow` is not currently implemented.');
+    }
+
+    const buffer = Math.max(data.buffer ?? 1, 1);
+    // let offset = Math.max(Math.min(data.offset, data.currentPage - buffer), 0);
+    let offset = 0;
+    let windowLength =
+      Math.max(data.offset + data.windowLength, data.currentPage + buffer + 1) -
+      offset;
+
+    // let maxRenderWindow = data.maxRenderWindow ?? 0;
+    let maxRenderWindow = 0;
+    if (maxRenderWindow !== 0) {
+      maxRenderWindow = Math.max(maxRenderWindow, 1 + 2 * buffer);
+      if (windowLength > maxRenderWindow) {
+        offset = data.currentPage - Math.floor(maxRenderWindow / 2);
+        windowLength = maxRenderWindow;
+      }
+    }
+
+    return { offset, windowLength };
+  }
+
+  private onMoveShouldSetResponderCapture = () => this.isScrolling;
+
+  private onPageScroll = (event: PagerViewOnPageScrollEvent) => {
+    this.props.onPageScroll?.(event);
+    if (this.props.keyboardDismissMode === 'on-drag') {
+      Keyboard.dismiss();
+    }
+  };
+
+  private onPageScrollStateChanged = (
+    event: PageScrollStateChangedNativeEvent
+  ) => {
+    this.props.onPageScrollStateChanged?.(event);
+    this.isScrolling = event.nativeEvent.pageScrollState === 'dragging';
+  };
+
+  private onPageSelected = (event: PagerViewOnPageSelectedEvent) => {
+    const currentPage = event.nativeEvent.position;
+    this.setState((prevState) =>
+      this.computeRenderWindow({
+        buffer: this.props.buffer,
+        currentPage,
+        maxRenderWindow: this.props.maxRenderWindow,
+        offset: prevState.offset,
+        windowLength: prevState.windowLength,
+      })
+    );
+    this.props.onPageSelected?.(event);
+  };
+
+  private renderChildren(offset: number, windowLength: number) {
+    const keys: string[] = [];
+    return {
+      children: this.props.data
+        .slice(offset, offset + windowLength)
+        .map((item, index) => {
+          const key = this.props.keyExtractor(item, offset + index);
+          keys.push(key);
+          return (
+            <View collapsable={false} key={key} style={styles.pageContainer}>
+              {this.props.renderItem({ item, index: offset + index })}
+            </View>
+          );
+        }),
+      keys,
+    };
+  }
+
+  render() {
+    // Note: current implementation does not support unmounting, so `offset`
+    // is always `0`.
+    const { offset, windowLength } = this.state;
+    const { children } = this.renderChildren(offset, windowLength);
+
+    return (
+      <PagerViewViewManager
+        offscreenPageLimit={this.props.offscreenPageLimit}
+        onMoveShouldSetResponderCapture={this.onMoveShouldSetResponderCapture}
+        onPageScroll={this.onPageScroll}
+        onPageScrollStateChanged={this.onPageScrollStateChanged}
+        onPageSelected={this.onPageSelected}
+        orientation={this.props.orientation}
+        overdrag={this.props.overdrag}
+        overScrollMode={this.props.overScrollMode}
+        pageMargin={this.props.pageMargin}
+        scrollEnabled={this.props.scrollEnabled}
+        showPageIndicator={this.props.showPageIndicator}
+        style={this.props.style}
+        transitionStyle={this.props.transitionStyle}
+      >
+        {children}
+      </PagerViewViewManager>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  pageContainer: { height: '100%', position: 'absolute', width: '100%' },
+});

--- a/src/LazyPagerView.tsx
+++ b/src/LazyPagerView.tsx
@@ -28,7 +28,7 @@ type RenderWindowData = {
 };
 
 /**
- * PagerView implementation that renders pages on demand.
+ * PagerView implementation that renders pages when needed (lazy loading)
  *
  * Note: under current implementation, pages are never unloaded. Also, all
  * pages before the visible page are rendered.

--- a/src/PagerView.tsx
+++ b/src/PagerView.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Platform, UIManager, Keyboard } from 'react-native';
 import ReactNative from 'react-native';
 import type {
+  Pageable,
   PagerViewOnPageScrollEvent,
   PagerViewOnPageSelectedEvent,
   PageScrollStateChangedNativeEvent,
@@ -53,7 +54,9 @@ import { getViewManagerConfig, PagerViewViewManager } from './PagerViewNative';
  * ```
  */
 
-export class PagerView extends React.Component<PagerViewProps> {
+export class PagerView
+  extends React.Component<PagerViewProps>
+  implements Pageable {
   private isScrolling = false;
 
   componentDidMount() {

--- a/src/PagerView.tsx
+++ b/src/PagerView.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
 import { Platform, UIManager, Keyboard } from 'react-native';
 import ReactNative from 'react-native';
 import type {
@@ -55,7 +55,6 @@ import { getViewManagerConfig, PagerViewViewManager } from './PagerViewNative';
 
 export class PagerView extends React.Component<PagerViewProps> {
   private isScrolling = false;
-  private PagerView = React.createRef<typeof PagerViewViewManager>();
 
   componentDidMount() {
     // On iOS we do it directly on the native side
@@ -67,10 +66,6 @@ export class PagerView extends React.Component<PagerViewProps> {
       });
     }
   }
-
-  public getInnerViewNode = (): ReactElement => {
-    return this.PagerView.current!.getInnerViewNode();
-  };
 
   private _onPageScroll = (e: PagerViewOnPageScrollEvent) => {
     if (this.props.onPageScroll) {
@@ -144,7 +139,6 @@ export class PagerView extends React.Component<PagerViewProps> {
     return (
       <PagerViewViewManager
         {...this.props}
-        ref={this.PagerView as any /** TODO: Fix ref type */}
         style={this.props.style}
         onPageScroll={this._onPageScroll}
         onPageScrollStateChanged={this._onPageScrollStateChanged}

--- a/src/PagerViewNative.tsx
+++ b/src/PagerViewNative.tsx
@@ -1,16 +1,45 @@
-import type { ReactElement } from 'react';
-import { HostComponent, requireNativeComponent, UIManager } from 'react-native';
-import type { PagerViewProps } from './types';
+import { requireNativeComponent, UIManager } from 'react-native';
+import type { GestureResponderEvent, StyleProp, ViewStyle } from 'react-native';
+import type {
+  Orientation,
+  OverScrollMode,
+  PagerViewOnPageScrollEvent,
+  PagerViewOnPageSelectedEvent,
+  PageScrollStateChangedNativeEvent,
+  TransitionStyle,
+} from './types';
 
 const VIEW_MANAGER_NAME = 'RNCViewPager';
 
-interface PagerViewViewManagerType extends HostComponent<PagerViewProps> {
-  getInnerViewNode(): ReactElement;
-}
+type PagerViewNativeProps = {
+  offscreenPageLimit?: number;
 
-export const PagerViewViewManager = requireNativeComponent(
+  /**
+   * If a parent `View` wants to prevent a child `View` from becoming responder
+   * on a move, it should have this handler which returns `true`.
+   *
+   * `View.props.onMoveShouldSetResponderCapture: (event) => [true | false]`,
+   * where `event` is a synthetic touch event as described above.
+   *
+   * See http://facebook.github.io/react-native/docs/view.html#onMoveShouldsetrespondercapture
+   */
+  onMoveShouldSetResponderCapture: (event: GestureResponderEvent) => boolean;
+  onPageScroll: (event: PagerViewOnPageScrollEvent) => void;
+  onPageScrollStateChanged: (event: PageScrollStateChangedNativeEvent) => void;
+  onPageSelected: (event: PagerViewOnPageSelectedEvent) => void;
+  orientation?: Orientation;
+  overdrag?: boolean;
+  overScrollMode?: OverScrollMode;
+  pageMargin?: number;
+  scrollEnabled?: boolean;
+  showPageIndicator?: boolean;
+  style: StyleProp<ViewStyle>;
+  transitionStyle?: TransitionStyle;
+};
+
+export const PagerViewViewManager = requireNativeComponent<PagerViewNativeProps>(
   VIEW_MANAGER_NAME
-) as PagerViewViewManagerType;
+);
 
 export function getViewManagerConfig(viewManagerName = VIEW_MANAGER_NAME) {
   return UIManager.getViewManagerConfig(viewManagerName);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,3 @@
 export * from './types';
-import { PagerView } from './PagerView';
-export default PagerView;
+export { LazyPagerView } from './LazyPagerView';
+export { PagerView } from './PagerView';

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,30 @@ export interface PageScrollStateChangedEvent {
   pageScrollState: PageScrollState;
 }
 
+/**
+ * Supports imperative paging commands.
+ */
+export interface Pageable {
+  /**
+   * A helper function to scroll to a specific page in the PagerView.
+   * The transition between pages will be animated.
+   */
+  setPage(page: number): void;
+
+  /**
+   * A helper function to scroll to a specific page in the PagerView.
+   * The transition between pages will *not* be animated.
+   */
+  setPageWithoutAnimation(page: number): void;
+
+  /**
+   * A helper function to enable/disable scroll imperatively
+   * The recommended way is using the scrollEnabled prop, however, there might be a case where a
+   * imperative solution is more useful (e.g. for not blocking an animation)
+   */
+  setScrollEnabled(scrollEnabled: boolean): void;
+}
+
 export interface PagerViewProps {
   /**
    * Index of initial page that should be selected. Use `setPage` method to

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,3 @@
-import type { ReactNode } from 'react';
 import type * as ReactNative from 'react-native';
 
 export type TransitionStyle = 'scroll' | 'curl';
@@ -89,21 +88,6 @@ export interface PagerViewProps {
    */
   offscreenPageLimit?: number;
 
-  children: ReactNode;
-
-  /**
-   * If a parent `View` wants to prevent a child `View` from becoming responder
-   * on a move, it should have this handler which returns `true`.
-   *
-   * `View.props.onMoveShouldSetResponderCapture: (event) => [true | false]`,
-   * where `event` is a synthetic touch event as described above.
-   *
-   * See http://facebook.github.io/react-native/docs/view.html#onMoveShouldsetrespondercapture
-   */
-  onMoveShouldSetResponderCapture?: (
-    event: ReactNative.GestureResponderEvent
-  ) => boolean;
-
   /**
    * iOS only
    */
@@ -119,4 +103,35 @@ export interface PagerViewProps {
    * after reaching end or very beginning of pages.
    */
   overdrag?: boolean;
+}
+
+export interface LazyPagerViewProps<ItemT> extends PagerViewProps {
+  /**
+   * Number of pages to render before/after the current page. Minimum 1.
+   */
+  buffer?: number;
+
+  /**
+   * Array of data to be rendered as pages.
+   */
+  data: ItemT[];
+
+  /**
+   * Compute a unique key for the given item at the specified index.
+   */
+  keyExtractor: (item: ItemT, index: number) => string;
+
+  /**
+   * Note: not currently implemented.
+   *
+   * Maximum number of pages allowed to stay rendered. Set to 0 for unlimited.
+   *
+   * Default unlimited. Will always render at least `1 + 2 * buffer` pages.
+   */
+  maxRenderWindow?: number;
+
+  /**
+   * Render an item from `data` into a page.
+   */
+  renderItem: (info: { item: ItemT; index: number }) => React.ReactElement;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7784,7 +7784,7 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
   integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
 
-react-native-builder-bob@^:
+react-native-builder-bob@^0.18.1:
   version "0.18.1"
   resolved "https://registry.yarnpkg.com/react-native-builder-bob/-/react-native-builder-bob-0.18.1.tgz#43f238e6cb6efffa6e3d23ac449eb7392650c2c3"
   integrity sha512-cFhgXLE30HaY4APDxaXA/cwuL3xl0Rser75yLrVTfHQquPqCoixNs+cc97Cbk/nInkkDmHzBoJkC3tVItqKRsQ==


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Enables pages to be rendered on demand, instead of all at once.  This is the JS specific changes.  Several parts are commented out, awaiting the associated native changes.

Split from #279.  Note that due to lack of native support (will be done in another pr), all pages prior to the current page will always be rendered.  So starting in the middle/end of a large number of pages is not very efficient.  Also, pager will not navigate to a page until the page is rendered (requires native support).  This can lead to feeling stuck if swiping quickly through heavy pages.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

- Checkout of this branch (unmodified).
- Checkout of this branch, patched to show renders.
<details>
<summary><tt>track-page-renders.patch</tt></summary>

```diff
diff --git a/example/src/BasicPagerViewExample.tsx b/example/src/BasicPagerViewExample.tsx
index 48ad5a4..6c45a69 100644
--- a/example/src/BasicPagerViewExample.tsx
+++ b/example/src/BasicPagerViewExample.tsx
@@ -15,6 +15,17 @@ function keyExtractor(page: CreatePage) {
 }
 
 function renderItem({ item }: { item: CreatePage }) {
+  return <TrackingRender item={item} />;
+}
+
+function TrackingRender({ item }: { item: CreatePage }) {
+  React.useEffect(() => {
+    console.log(`didmout ${item.key}`);
+    return () => {
+      console.log(`didunmout ${item.key}`);
+    };
+  }, [item.key]);
+
   return (
     <View style={item.style}>
       <Image style={styles.image} source={item.imgSource} />
```

</details>

### What are the steps to reproduce (after prerequisites)?

In the unmodified checkout, all examples should work the same as in `master`.

In the patched checkout, logs in metro should show the basic example is rendering pages incrementally, instead of all ahead of time.  Optionally add the prop `buffer={3}` (or some other number) to the pager view to change the prerender distance.

Note that only the basic example has been converted to lazy loading.  The other examples still use eager render (same as `master`).

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
