### PR TITLE
Lazy pager (Android native side)

### DIFF
--- a/android/src/main/java/com/reactnativepagerview/FragmentAdapter.kt
+++ b/android/src/main/java/com/reactnativepagerview/FragmentAdapter.kt
@@ -3,54 +3,98 @@ package com.reactnativepagerview
 import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
+import androidx.recyclerview.widget.DiffUtil
 import androidx.viewpager2.adapter.FragmentStateAdapter
-import java.util.*
 
 
 class FragmentAdapter(fragmentActivity: FragmentActivity) : FragmentStateAdapter(fragmentActivity) {
-  private val childrenViews: MutableList<View> = ArrayList()
+  private val childrenViews = mutableListOf<View>()
+  private var count = 0
+  private var offset = 0
+  private var isDirty = false
+  private val prevItemIds = mutableListOf<Long>()
+
   override fun createFragment(position: Int): Fragment {
-    return ViewPagerFragment(childrenViews[position])
+    return ViewPagerFragment(getViewAtPosition(position))
   }
 
-  override fun getItemCount(): Int {
-    return childrenViews.size
-  }
+  override fun getItemCount() = count
 
   override fun getItemId(position: Int): Long {
-    return childrenViews[position].id.toLong()
+    val view = getViewAtPosition(position)
+    return view?.id?.toLong() ?: UNRENDERED_ID_OFFSET + position
   }
 
   override fun containsItem(itemId: Long): Boolean {
-    for (child in childrenViews) {
-      if (itemId.toInt() == child.id) {
-        return true
-      }
+    if (itemId >= UNRENDERED_ID_OFFSET) {
+      val position = itemId - UNRENDERED_ID_OFFSET
+      return getViewAtPosition(position.toInt()) == null
     }
-    return false
+    return childrenViews.any { it.id.toLong() == itemId }
   }
 
-  fun addFragment(child: View, index: Int) {
+  /**
+   * Returns true if any changes were applied.
+   */
+  fun applyChanges(): Boolean {
+    if (!isDirty) {
+      return false
+    }
+
+    isDirty = false
+    val diff = DiffUtil.calculateDiff(
+      PagerDiffCallback(prevItemIds, this),
+      false
+    )
+    diff.dispatchUpdatesTo(this)
+    return true
+  }
+
+  fun setCount(count: Int) {
+    if (this.count != count) {
+      markDirty()
+      this.count = count
+    }
+  }
+
+  fun setOffset(offset: Int) {
+    if (this.offset != offset) {
+      markDirty()
+      this.offset = offset
+    }
+  }
+
+  fun addReactView(child: View, index: Int) {
+    markDirty()
     childrenViews.add(index, child)
-    notifyItemInserted(index)
   }
 
-  fun removeFragment(child: View) {
-    val index = childrenViews.indexOf(child)
-    removeFragmentAt(index)
-  }
+  fun getReactChildAt(index: Int) = childrenViews[index]
 
-  fun removeFragmentAt(index: Int) {
+  fun getReactChildCount() = childrenViews.size
+
+  fun removeReactViewAt(index: Int) {
+    markDirty()
     childrenViews.removeAt(index)
-    notifyItemRemoved(index)
   }
 
-  fun removeAll() {
-    childrenViews.clear()
-    notifyDataSetChanged()
+  private fun getViewAtPosition(position: Int): View? {
+    val index = position - offset
+    return if (index >= 0 && index < childrenViews.size) childrenViews[index] else null
   }
 
-  fun getChildViewAt(index: Int): View {
-    return childrenViews[index]
+  private fun markDirty() {
+    if (isDirty) {
+      return
+    }
+    isDirty = true
+    prevItemIds.clear()
+    for (position in 0 until itemCount) {
+      prevItemIds.add(getItemId(position))
+    }
+  }
+
+  companion object {
+     const val UNRENDERED_ID_OFFSET = 0xffffffffL
   }
 }

--- a/android/src/main/java/com/reactnativepagerview/FragmentAdapter.kt
+++ b/android/src/main/java/com/reactnativepagerview/FragmentAdapter.kt
@@ -36,7 +36,7 @@ class FragmentAdapter(fragmentActivity: FragmentActivity) : FragmentStateAdapter
   /**
    * Returns true if any changes were applied.
    */
-  fun applyChanges(): Boolean {
+  fun notifyAboutChanges(): Boolean {
     if (!isDirty) {
       return false
     }
@@ -95,6 +95,10 @@ class FragmentAdapter(fragmentActivity: FragmentActivity) : FragmentStateAdapter
   }
 
   companion object {
-     const val UNRENDERED_ID_OFFSET = 0xffffffffL
+    /**
+     * If an id is `UNRENDERED_ID_OFFSET` or higher, it represents a view
+     * that is not currently rendered.
+     */
+    const val UNRENDERED_ID_OFFSET = 0xffffffffL
   }
 }

--- a/android/src/main/java/com/reactnativepagerview/PagerDiffCallback.kt
+++ b/android/src/main/java/com/reactnativepagerview/PagerDiffCallback.kt
@@ -1,0 +1,25 @@
+package com.reactnativepagerview
+
+import androidx.recyclerview.widget.DiffUtil
+import com.reactnativepagerview.FragmentAdapter.Companion.UNRENDERED_ID_OFFSET
+
+class PagerDiffCallback(private val oldList: List<Long>, private val adapter: FragmentAdapter) : DiffUtil.Callback() {
+  override fun getOldListSize() = oldList.size
+
+  override fun getNewListSize() = adapter.itemCount
+
+  override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+    val oldId = oldList[oldItemPosition]
+    val newId = adapter.getItemId(newItemPosition)
+    if (UNRENDERED_ID_OFFSET in (newId + 1)..oldId) {
+      // When the old item is not rendered but the new item is rendered,
+      // consider the same if the items are in the same position.
+      return oldItemPosition == newItemPosition
+    }
+    return oldId == newId
+  }
+
+  override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+    return oldList[oldItemPosition] == adapter.getItemId(newItemPosition)
+  }
+}

--- a/android/src/main/java/com/reactnativepagerview/PagerDiffCallback.kt
+++ b/android/src/main/java/com/reactnativepagerview/PagerDiffCallback.kt
@@ -11,9 +11,8 @@ class PagerDiffCallback(private val oldList: List<Long>, private val adapter: Fr
   override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
     val oldId = oldList[oldItemPosition]
     val newId = adapter.getItemId(newItemPosition)
-    if (UNRENDERED_ID_OFFSET in (newId + 1)..oldId) {
-      // When the old item is not rendered but the new item is rendered,
-      // consider the same if the items are in the same position.
+    if (oldId >= UNRENDERED_ID_OFFSET || newId >= UNRENDERED_ID_OFFSET) {
+      // An unrendered item is assumed the same as any item in the same position.
       return oldItemPosition == newItemPosition
     }
     return oldId == newId

--- a/android/src/main/java/com/reactnativepagerview/PagerDiffCallback.kt
+++ b/android/src/main/java/com/reactnativepagerview/PagerDiffCallback.kt
@@ -11,11 +11,8 @@ class PagerDiffCallback(private val oldList: List<Long>, private val adapter: Fr
   override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
     val oldId = oldList[oldItemPosition]
     val newId = adapter.getItemId(newItemPosition)
-    if (oldId >= UNRENDERED_ID_OFFSET || newId >= UNRENDERED_ID_OFFSET) {
-      // An unrendered item is assumed the same as any item in the same position.
-      return oldItemPosition == newItemPosition
-    }
-    return oldId == newId
+    // An unrendered item is assumed the same as any item in the same position.
+    return if (oldId >= UNRENDERED_ID_OFFSET || newId >= UNRENDERED_ID_OFFSET) oldItemPosition == newItemPosition else oldId == newId
   }
 
   override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {

--- a/src/PagerView.tsx
+++ b/src/PagerView.tsx
@@ -142,6 +142,8 @@ export class PagerView
     return (
       <PagerViewViewManager
         {...this.props}
+        count={React.Children.count(this.props.children)}
+        offset={0}
         style={this.props.style}
         onPageScroll={this._onPageScroll}
         onPageScrollStateChanged={this._onPageScrollStateChanged}

--- a/src/PagerViewNative.tsx
+++ b/src/PagerViewNative.tsx
@@ -12,7 +12,19 @@ import type {
 const VIEW_MANAGER_NAME = 'RNCViewPager';
 
 type PagerViewNativeProps = {
+  /**
+   * Total number of pages. When lazy rendering, number of rendered react
+   * children elements will be smaller.
+   */
+  count: number;
   offscreenPageLimit?: number;
+
+  /**
+   * Page position offset of the first rendered react child. I.e., the first
+   * `offset` number of pages are not currently rendered on JS-side (so native
+   * code should act accordingly).
+   */
+  offset: number;
 
   /**
    * If a parent `View` wants to prevent a child `View` from becoming responder

--- a/src/types.ts
+++ b/src/types.ts
@@ -146,8 +146,6 @@ export interface LazyPagerViewProps<ItemT> extends PagerViewProps {
   keyExtractor: (item: ItemT, index: number) => string;
 
   /**
-   * Note: not currently implemented.
-   *
    * Maximum number of pages allowed to stay rendered. Set to 0 for unlimited.
    *
    * Default unlimited. Will always render at least `1 + 2 * buffer` pages.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->
Enables pages to be rendered on demand, instead of all at once. This is the Android native code changes.

Split from #279. Note that this builds on top of #326, so when reviewing code, may be easier to check the specific commits that are not in #326.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

- Checkout of this branch (unmodified).
- Checkout of this branch, patched to show renders.
<details>
<summary><tt>track-page-renders.patch</tt></summary>

```diff
diff --git a/example/src/BasicPagerViewExample.tsx b/example/src/BasicPagerViewExample.tsx
index 48ad5a4..69df7a3 100644
--- a/example/src/BasicPagerViewExample.tsx
+++ b/example/src/BasicPagerViewExample.tsx
@@ -15,6 +15,17 @@ function keyExtractor(page: CreatePage) {
 }
 
 function renderItem({ item }: { item: CreatePage }) {
+  return <TrackingRender item={item} />;
+}
+
+function TrackingRender({ item }: { item: CreatePage }) {
+  React.useEffect(() => {
+    console.log(`didmout ${item.key}`);
+    return () => {
+      console.log(`didunmout ${item.key}`);
+    };
+  }, [item.key]);
+
   return (
     <View style={item.style}>
       <Image style={styles.image} source={item.imgSource} />
@@ -26,16 +37,18 @@ function renderItem({ item }: { item: CreatePage }) {
 export function BasicPagerViewExample() {
   const { ref, ...navigationPanel } = useNavigationPanel<
     LazyPagerView<unknown>
-  >();
+  >(10000);
 
   return (
     <SafeAreaView style={styles.container}>
       <AnimatedPagerView
+        buffer={2}
         ref={ref}
         style={styles.PagerView}
         initialPage={0}
         overdrag={navigationPanel.overdragEnabled}
         scrollEnabled={navigationPanel.scrollEnabled}
+        maxRenderWindow={20}
         onPageScroll={navigationPanel.onPageScroll}
         onPageSelected={navigationPanel.onPageSelected}
         onPageScrollStateChanged={navigationPanel.onPageScrollStateChanged}
```

</details>

### What are the steps to reproduce (after prerequisites)?

In the unmodified checkout, all examples should work the same as in `master`.

In the patched checkout, the basic example should now handle displaying 10000 pages (does not work in `master`). Watching metro, page renders should show mounts/unmounts at reasonable times (e.g., swiping a few pages forward, then back again should not trigger any unmounts, but swiping many pages in a single direction (or jump to end) should unmount far away pages).

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
