### PR TITLE
fix: onPageSelected not called on ios

### DIFF
--- a/ios/ReactNativePageView.h
+++ b/ios/ReactNativePageView.h
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher;
 
 @property(nonatomic) NSInteger initialPage;
-@property(nonatomic) NSInteger previousIndex;
+@property(nonatomic) NSInteger lastReportedIndex;
 @property(nonatomic) NSInteger currentIndex;
 @property(nonatomic) NSInteger pageMargin;
 @property(nonatomic, readonly) BOOL scrollEnabled;

--- a/ios/ReactNativePageView.m
+++ b/ios/ReactNativePageView.m
@@ -36,7 +36,7 @@
     if (self = [super init]) {
         _scrollEnabled = YES;
         _pageMargin = 0;
-        _previousIndex = -1;
+        _lastReportedIndex = -1;
         _transitionStyle = UIPageViewControllerTransitionStyleScroll;
         _orientation = UIPageViewControllerNavigationOrientationHorizontal;
         _currentIndex = 0;
@@ -169,17 +169,16 @@
                                            direction:direction
                                             animated:animated
                                           completion:^(BOOL finished) {
+        __strong typeof(self) strongSelf = weakSelf;
+        strongSelf.currentIndex = index;
+        strongSelf.currentView = controller.view;
         
-        weakSelf.currentIndex = index;
-        weakSelf.currentView = controller.view;
-        
-        if (weakSelf.eventDispatcher) {
-            if(_previousIndex != _currentIndex){
-                [weakSelf.eventDispatcher sendEvent:[[RCTOnPageSelected alloc] initWithReactTag:weakSelf.reactTag position:@(index) coalescingKey:coalescingKey]];
+        if (strongSelf.eventDispatcher) {
+            if (strongSelf.lastReportedIndex != strongSelf.currentIndex) {
+                [strongSelf.eventDispatcher sendEvent:[[RCTOnPageSelected alloc] initWithReactTag:strongSelf.reactTag position:@(index) coalescingKey:coalescingKey]];
+                strongSelf.lastReportedIndex = strongSelf.currentIndex;
             }
-            _previousIndex = _currentIndex;
         }
-        
     }];
 }
 
@@ -284,12 +283,12 @@
         NSUInteger currentIndex = [self.reactSubviews indexOfObject:currentVC.view];
         
         self.currentIndex = currentIndex;
-        self.previousIndex = currentIndex - 1;
         self.currentView = currentVC.view;
         self.reactPageIndicatorView.currentPage = currentIndex;
         
         [self.eventDispatcher sendEvent:[[RCTOnPageSelected alloc] initWithReactTag:self.reactTag position:@(currentIndex) coalescingKey:_coalescingKey++]];
         [self.eventDispatcher sendEvent:[[RCTOnPageScrollEvent alloc] initWithReactTag:self.reactTag position:@(currentIndex) offset:@(0.0)]];
+        self.lastReportedIndex = currentIndex;
     }
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

this fixes an issue where `onPageSelected` callback is not fired on ios when it should

## Test Plan

how to reproduce the bug:

- render pager with 2 pages
- swipe from page index 0 to 1
- after running `self.previousIndex = currentIndex - 1;`, `self.previousIndex` will contain `0`
- now call `ref.current?.setPage(0)`. That triggers  the native listener and `if(_previousIndex != _currentIndex)` from line 177 will be `false` and so `[weakSelf.eventDispatcher sendEvent...` is not called and so `onPageSelected` callback is not fired in JS


the test plan followed the steps and the bug can no longer be reproduced

### What's required for testing (prerequisites)?

- ios simulator

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
