### PR TITLE
Fixes #339 - Handle the component unmounting

### DIFF
--- a/src/PagerView.tsx
+++ b/src/PagerView.tsx
@@ -55,11 +55,11 @@ import { getViewManagerConfig, PagerViewViewManager } from './PagerViewNative';
 
 export class PagerView extends React.Component<PagerViewProps> {
   private isScrolling = false;
-  private animationFrameRequestId = 0;
+  private animationFrameRequestId?: number;
   private PagerView = React.createRef<typeof PagerViewViewManager>();
 
   componentWillUnmount() {
-    if (this.animationFrameRequestId > 0) {
+    if (this.animationFrameRequestId !== undefined) {
       cancelAnimationFrame(this.animationFrameRequestId);
     }
   }

--- a/src/PagerView.tsx
+++ b/src/PagerView.tsx
@@ -55,12 +55,19 @@ import { getViewManagerConfig, PagerViewViewManager } from './PagerViewNative';
 
 export class PagerView extends React.Component<PagerViewProps> {
   private isScrolling = false;
+  private animationFrameRequestId = 0;
   private PagerView = React.createRef<typeof PagerViewViewManager>();
+
+  componentWillUnmount() {
+    if (this.animationFrameRequestId > 0) {
+      cancelAnimationFrame(this.animationFrameRequestId);
+    }
+  }
 
   componentDidMount() {
     // On iOS we do it directly on the native side
     if (Platform.OS === 'android' && this.props.initialPage !== undefined) {
-      requestAnimationFrame(() => {
+      this.animationFrameRequestId = requestAnimationFrame(() => {
         if (this.props.initialPage !== undefined) {
           this.setPageWithoutAnimation(this.props.initialPage);
         }


### PR DESCRIPTION
# Summary
Fixes #339: If the component unmounts immediately after mounting, then the call to requestAnimationFrame will attempt to operate on the unmounted component. We can prevent this by ensuring we cleanup the callback on unmounting.

## Test Plan

Manually tested using reproduction steps of bug. A before and after gif is included below. The examples below test this change in a fairly tight loop, hence the error appearing multiple times in the console output. There's also some diagnostic logging that doesn't feature in this PR:

#### Before Change
![Error](https://user-images.githubusercontent.com/1374775/116375902-a451e500-a807-11eb-86d7-2521adcbd639.gif)

#### After Change
![Works](https://user-images.githubusercontent.com/1374775/116375912-a61ba880-a807-11eb-81ae-e7e1f2b6640e.gif)

### What's required for testing (prerequisites)?
- NodeJS
- Android Emulator

### What are the steps to reproduce (after prerequisites)?
```
npx create-react-native-app foobar (accept default)
npm install react-native-pager-view
```

Modify `App.js` to contain the following, which is a slight modification from the bug reproduction steps:
```
import { StatusBar } from 'expo-status-bar';
import React, { useState } from 'react';
import { StyleSheet, Text, View } from 'react-native';
import PagerView from 'react-native-pager-view';

const Pager = () => (
  <React.Fragment>
    <Text>This is a Pager</Text>
    <PagerView initialPage={0}>
      <View key={0}>
        <Text>PagerContents</Text>
      </View>
    </PagerView>
  </React.Fragment>
);

const NotAPager = () => (
  <React.Fragment>
    <Text>This is NOT a Pager</Text>
  </React.Fragment>
);

export default function App() {
  const [flag, setFlag] = useState(true);

  setTimeout(() => {
    setFlag(!flag);
  }, 1);

  return (
    <View style={styles.container}>
      <Text>Open up App.js to start working on your app!</Text>
      <StatusBar style="auto" />
      {flag ? <Pager /> : <NotAPager />}
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    backgroundColor: '#fff',
    alignItems: 'center',
    justifyContent: 'center',
  },
});
```
In two different terminals run:
`npm start`
`npm run android`

## Compatibility
This is just a change in the JavaScript so should work on both platforms

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅       |
| Android |    ✅       |

## Checklist
- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [X] I updated the typed files (TS and Flow)
