### PR TITLE
fix(ios): offset is changing  while overDrag is disabled

### DIFF
--- a/ios/ReactNativePageView.m
+++ b/ios/ReactNativePageView.m
@@ -363,14 +363,6 @@
 
     float offset = 0;
     
-    if (!_overdrag) {
-        if (_currentIndex == 0 && scrollView.contentOffset.x < scrollView.bounds.size.width) {
-            scrollView.contentOffset = CGPointMake(scrollView.bounds.size.width, 0);
-        } else if (_currentIndex == _reactPageIndicatorView.numberOfPages - 1 && scrollView.contentOffset.x > scrollView.bounds.size.width) {
-            scrollView.contentOffset = CGPointMake(scrollView.bounds.size.width, 0);
-        }
-    }
-    
     if (self.isHorizontal) {
         if (self.frame.size.width != 0) {
             offset = (point.x - self.frame.size.width)/self.frame.size.width;
@@ -388,6 +380,16 @@
     if(offset<0 && position>0){
         position =  self.currentIndex - 1;
         absoluteOffset =  1 - absoluteOffset;
+    }
+    
+    if (!_overdrag) {
+        if (_currentIndex == 0 && scrollView.contentOffset.x < scrollView.bounds.size.width) {
+            scrollView.contentOffset = CGPointMake(scrollView.bounds.size.width, 0);
+            absoluteOffset=0;
+        } else if (_currentIndex == _reactPageIndicatorView.numberOfPages - 1 && scrollView.contentOffset.x > scrollView.bounds.size.width) {
+            scrollView.contentOffset = CGPointMake(scrollView.bounds.size.width, 0);
+            absoluteOffset=0;
+        }
     }
     
     self.lastContentOffset = scrollView.contentOffset;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

When disabling overDrag on iOs and swiping right on the first page to trigger it the `offset` would change between `0` and `0.05...`. This can be seen on the Headphone example. ( need to add `overDrag={false}` prop to the pager component ) 

I fixed it by setting the `offset` to `0` when it goes into the `!_overDrag` logic.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan
Before:

https://user-images.githubusercontent.com/50402950/119804695-e17dc580-bee0-11eb-9946-d080ba9c945e.mp4

After:

https://user-images.githubusercontent.com/50402950/119805009-299ce800-bee1-11eb-968e-1cecf723b710.mp4



<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
