### PR TITLE
fix: blinking on android when initialPage is used

### DIFF
--- a/android/src/main/java/com/reactnativepagerview/FragmentAdapter.kt
+++ b/android/src/main/java/com/reactnativepagerview/FragmentAdapter.kt
@@ -9,6 +9,8 @@ import java.util.*
 
 class FragmentAdapter(fragmentActivity: FragmentActivity) : FragmentStateAdapter(fragmentActivity) {
   private val childrenViews: MutableList<View> = ArrayList()
+  var initialPageinited = false
+
   override fun createFragment(position: Int): Fragment {
     return ViewPagerFragment(childrenViews[position])
   }

--- a/android/src/main/java/com/reactnativepagerview/PagerViewViewManager.kt
+++ b/android/src/main/java/com/reactnativepagerview/PagerViewViewManager.kt
@@ -32,31 +32,34 @@ class PagerViewViewManager : ViewGroupManager<ViewPager2>() {
     //https://github.com/callstack/react-native-viewpager/issues/183
     vp.isSaveEnabled = false
     eventDispatcher = reactContext.getNativeModule(UIManagerModule::class.java)!!.eventDispatcher
-    vp.registerOnPageChangeCallback(object : OnPageChangeCallback() {
-      override fun onPageScrolled(position: Int, positionOffset: Float, positionOffsetPixels: Int) {
-        super.onPageScrolled(position, positionOffset, positionOffsetPixels)
-        eventDispatcher.dispatchEvent(
-          PageScrollEvent(vp.id, position, positionOffset))
-      }
 
-      override fun onPageSelected(position: Int) {
-        super.onPageSelected(position)
-        eventDispatcher.dispatchEvent(
-          PageSelectedEvent(vp.id, position))
-      }
-
-      override fun onPageScrollStateChanged(state: Int) {
-        super.onPageScrollStateChanged(state)
-        val pageScrollState: String = when (state) {
-          ViewPager2.SCROLL_STATE_IDLE -> "idle"
-          ViewPager2.SCROLL_STATE_DRAGGING -> "dragging"
-          ViewPager2.SCROLL_STATE_SETTLING -> "settling"
-          else -> throw IllegalStateException("Unsupported pageScrollState")
+    vp.post {
+      vp.registerOnPageChangeCallback(object : OnPageChangeCallback() {
+        override fun onPageScrolled(position: Int, positionOffset: Float, positionOffsetPixels: Int) {
+          super.onPageScrolled(position, positionOffset, positionOffsetPixels)
+          eventDispatcher.dispatchEvent(
+            PageScrollEvent(vp.id, position, positionOffset))
         }
-        eventDispatcher.dispatchEvent(
-          PageScrollStateChangedEvent(vp.id, pageScrollState))
-      }
-    })
+
+        override fun onPageSelected(position: Int) {
+          super.onPageSelected(position)
+          eventDispatcher.dispatchEvent(
+            PageSelectedEvent(vp.id, position))
+        }
+
+        override fun onPageScrollStateChanged(state: Int) {
+          super.onPageScrollStateChanged(state)
+          val pageScrollState: String = when (state) {
+            ViewPager2.SCROLL_STATE_IDLE -> "idle"
+            ViewPager2.SCROLL_STATE_DRAGGING -> "dragging"
+            ViewPager2.SCROLL_STATE_SETTLING -> "settling"
+            else -> throw IllegalStateException("Unsupported pageScrollState")
+          }
+          eventDispatcher.dispatchEvent(
+            PageScrollStateChangedEvent(vp.id, pageScrollState))
+        }
+      })
+    }
     return vp
   }
 
@@ -196,6 +199,17 @@ class PagerViewViewManager : ViewGroupManager<ViewPager2>() {
         page.translationX = if (isRTL) -offset else offset
       } else {
         page.translationY = offset
+      }
+    }
+  }
+
+
+  @ReactProp(name = "initialPage", defaultInt = 0)
+  fun setInitialPage(viewPager: ViewPager2, value: Int) {
+    viewPager.post {
+      if (!(viewPager.adapter as FragmentAdapter).initialPageinited) {
+        (viewPager.adapter as FragmentAdapter).initialPageinited = true
+        setCurrentItem(viewPager, value, false)
       }
     }
   }

--- a/src/PagerView.tsx
+++ b/src/PagerView.tsx
@@ -55,25 +55,7 @@ import { getViewManagerConfig, PagerViewViewManager } from './PagerViewNative';
 
 export class PagerView extends React.Component<PagerViewProps> {
   private isScrolling = false;
-  private animationFrameRequestId?: number;
   private PagerView = React.createRef<typeof PagerViewViewManager>();
-
-  componentWillUnmount() {
-    if (this.animationFrameRequestId !== undefined) {
-      cancelAnimationFrame(this.animationFrameRequestId);
-    }
-  }
-
-  componentDidMount() {
-    // On iOS we do it directly on the native side
-    if (Platform.OS === 'android' && this.props.initialPage !== undefined) {
-      this.animationFrameRequestId = requestAnimationFrame(() => {
-        if (this.props.initialPage !== undefined) {
-          this.setPageWithoutAnimation(this.props.initialPage);
-        }
-      });
-    }
-  }
 
   public getInnerViewNode = (): ReactElement => {
     return this.PagerView.current!.getInnerViewNode();


### PR DESCRIPTION
# Summary

This is more of showing how to fix the problem than the actual fix (unfortunately I couldn't build the code because I don't use typescript)

Currently, when we use initialPage on android, the change of the initial page is done with JS and requestAnimationFrame, which delays the call. When the pager-view is embedded in the navigation, this causes an initial blinking (or showing the first page briefly).
Additionally, initialPage causes a double call to onPageSelected (first with page = 0, then with page = initalPage).

This solution slightly changes the behavior of events. I'm delaying adding callbacks with evants here so that onPageSelected is not called initially.
I also puted setting initalPage straight to the native module so that delay is insignificant (and not affected by animations).

## What are the steps to reproduce (after prerequisites)?

1. create project with pager-view and react-navigation, add some stack with animations between screens
2. add pager-view on second screen and add any initalPage
3. check what happen when screen with pager-view is opened (doubled onPageSelected event and blinking)

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
