### PR TITLE
fix(ios): Allow disabling overdrag in vertical orientation

### DIFF
--- a/ios/ReactNativePageView.m
+++ b/ios/ReactNativePageView.m
@@ -342,10 +342,14 @@
     [self.eventDispatcher sendEvent:[[RCTOnPageScrollStateChanged alloc] initWithReactTag:self.reactTag state:@"settling" coalescingKey:_coalescingKey++]];
     
     if (!_overdrag) {
-        if (_currentIndex == 0 && scrollView.contentOffset.x <= scrollView.bounds.size.width) {
-            *targetContentOffset = CGPointMake(scrollView.bounds.size.width, 0);
-        } else if (_currentIndex == _reactPageIndicatorView.numberOfPages -1 && scrollView.contentOffset.x >= scrollView.bounds.size.width) {
-            *targetContentOffset = CGPointMake(scrollView.bounds.size.width, 0);
+        BOOL isFirstPage = _currentIndex == 0;
+        BOOL isLastPage = _currentIndex == _reactPageIndicatorView.numberOfPages - 1;
+        CGFloat contentOffset =[self isHorizontal] ? scrollView.contentOffset.x : scrollView.contentOffset.y;
+        CGFloat topBound = [self isHorizontal] ? scrollView.bounds.size.width : scrollView.bounds.size.height;
+        
+        if ((isFirstPage && contentOffset <= topBound) || (isLastPage && contentOffset >= topBound)) {
+            CGPoint croppedOffset = [self isHorizontal] ? CGPointMake(topBound, 0) : CGPointMake(0, topBound);
+            *targetContentOffset = croppedOffset;
         }
     }
 }
@@ -383,11 +387,14 @@
     }
     
     if (!_overdrag) {
-        if (_currentIndex == 0 && scrollView.contentOffset.x < scrollView.bounds.size.width) {
-            scrollView.contentOffset = CGPointMake(scrollView.bounds.size.width, 0);
-            absoluteOffset=0;
-        } else if (_currentIndex == _reactPageIndicatorView.numberOfPages - 1 && scrollView.contentOffset.x > scrollView.bounds.size.width) {
-            scrollView.contentOffset = CGPointMake(scrollView.bounds.size.width, 0);
+        BOOL isFirstPage = _currentIndex == 0;
+        BOOL isLastPage = _currentIndex == _reactPageIndicatorView.numberOfPages - 1;
+        CGFloat contentOffset =[self isHorizontal] ? scrollView.contentOffset.x : scrollView.contentOffset.y;
+        CGFloat topBound = [self isHorizontal] ? scrollView.bounds.size.width : scrollView.bounds.size.height;
+
+        if ((isFirstPage && contentOffset <= topBound) || (isLastPage && contentOffset >= topBound)) {
+            CGPoint croppedOffset = [self isHorizontal] ? CGPointMake(topBound, 0) : CGPointMake(0, topBound);
+            scrollView.contentOffset = croppedOffset;
             absoluteOffset=0;
         }
     }


### PR DESCRIPTION
# Summary

Solves #388.
Adds support for disabling overdrag in vertical mode.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

Run `Basic Example` with `orientation="vertical"` option.

### What are the steps to reproduce (after prerequisites)?

When first slide is active, try to scroll up - it animates bounce effect even when `overdrag` option is set to `false`

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
