### PR TITLE
fix(ios): removing last page

### DIFF
--- a/ios/ReactNativePageView.m
+++ b/ios/ReactNativePageView.m
@@ -204,7 +204,10 @@
     
     if (newIndex == NSNotFound) {
         // Current view was removed
-        [self goTo:self.currentIndex animated:NO];
+        NSInteger maxPage = self.reactSubviews.count - 1;
+        NSInteger fallbackIndex = self.currentIndex >= maxPage ? maxPage : self.currentIndex;
+        
+        [self goTo:fallbackIndex animated:NO];
     } else {
         [self goTo:newIndex animated:NO];
     }


### PR DESCRIPTION
# Summary

Closes #109

On iOS removing last page while it is displayed resulted in blank screen rendered.
This change adjust the behavior to display closest remaining page instead.

## Test Plan

Before changes:

https://user-images.githubusercontent.com/746000/126478510-a2e42970-6b2a-4e59-bfb1-4dcbc33f98e9.mov



After changes:

https://user-images.githubusercontent.com/746000/126478533-42ddd4b0-7291-447d-b63e-532f1d092c2b.mov



### What's required for testing (prerequisites)?

Open `Basic example`

### What are the steps to reproduce (after prerequisites)?

Navigate to the last page and click `remove last page`

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
