### PR TITLE
fix(ios): emit correct progress values for overdrag

### DIFF
--- a/example/src/component/ProgressBar.tsx
+++ b/example/src/component/ProgressBar.tsx
@@ -13,12 +13,13 @@ export class ProgressBar extends React.Component<Props> {
   render() {
     const fractionalPosition =
       this.props.progress.position + this.props.progress.offset;
-
     const size = fractionalPosition / (this.props.numberOfPages - 1);
-    console.log(size);
+    const clampedSize = Math.max(0, Math.min(1, size));
     return (
       <View style={styles.progressBarContainer}>
-        <View style={[styles.progressBar, { width: `${size * 100}%` }]} />
+        <View
+          style={[styles.progressBar, { width: `${clampedSize * 100}%` }]}
+        />
       </View>
     );
   }

--- a/ios/ReactNativePageView.m
+++ b/ios/ReactNativePageView.m
@@ -389,15 +389,17 @@
     
 
     BOOL isAnimatingBackwards = ([self isLtrLayout] && offset<0) || (![self isLtrLayout] && offset > 0.05f);
-    if(isAnimatingBackwards && position > 0){
+    if(isAnimatingBackwards){
         position =  self.currentIndex - 1;
         absoluteOffset =  fmax(0, 1 - absoluteOffset);
     }
     
     if (!_overdrag) {
         NSInteger maxIndex = _reactPageIndicatorView.numberOfPages - 1;
-        BOOL isFirstPage = [self isLtrLayout] ? _currentIndex == 0 : _currentIndex == maxIndex;
-        BOOL isLastPage = [self isLtrLayout] ? _currentIndex == maxIndex : _currentIndex == 0;
+        NSInteger firstPageIndex = [self isLtrLayout] ?  0 :  maxIndex;
+        NSInteger lastPageIndex = [self isLtrLayout] ?  maxIndex :  0;
+        BOOL isFirstPage = _currentIndex == firstPageIndex;
+        BOOL isLastPage = _currentIndex == lastPageIndex;
         CGFloat contentOffset =[self isHorizontal] ? scrollView.contentOffset.x : scrollView.contentOffset.y;
         CGFloat topBound = [self isHorizontal] ? scrollView.bounds.size.width : scrollView.bounds.size.height;
 
@@ -405,6 +407,7 @@
             CGPoint croppedOffset = [self isHorizontal] ? CGPointMake(topBound, 0) : CGPointMake(0, topBound);
             scrollView.contentOffset = croppedOffset;
             absoluteOffset=0;
+            position = isLastPage ? lastPageIndex : firstPageIndex;
         }
     }
     


### PR DESCRIPTION
# Summary

Closes #330

On iOS there was an issue with progress values emitted during overdrag gesture.
During overdragging to the left, progress was positive, instead of negative.
As discussed in #330 - applied solution is to return `position: -1` during left overdrag which indicates the active page is negative. This way if neccessary user can consume negative offset, or simply clamp it within `<0, 1>` if negative values are not expected (i.e. `0-100%` progress bar in the examples control panel)

## Test Plan

Before changes:

https://user-images.githubusercontent.com/746000/126484187-027ee2bd-f06d-4e03-b198-69b9cc011896.mov


After changes:

https://user-images.githubusercontent.com/746000/126484196-0c82c509-fdbd-4dc6-9024-abdb950e79b4.mov


### What's required for testing (prerequisites)?

Open `Headhpones Example` with `overdrag={true}`.

### What are the steps to reproduce (after prerequisites)?

Swipe left to see overdrag behavior

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
