### PR TITLE
fix(android): implement getContext for the older versions of react native

### DIFF
--- a/android/src/main/java/com/reactnativepagerview/Helper.kt
+++ b/android/src/main/java/com/reactnativepagerview/Helper.kt
@@ -1,0 +1,21 @@
+package com.reactnativepagerview
+
+import android.content.Context
+import android.content.ContextWrapper
+import android.view.View
+import com.facebook.react.bridge.ReactContext
+
+
+class Helper {
+    companion object {
+        // https://github.com/facebook/react-native/blob/v0.64.2/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerHelper.java#L138
+        fun getReactContext(view: View): ReactContext? {
+            var context: Context = view.getContext()
+            if (context !is ReactContext && context is ContextWrapper) {
+                context = context.baseContext
+            }
+            return if (context is ReactContext) context else null;
+        }
+    }
+
+}

--- a/android/src/main/java/com/reactnativepagerview/PagerViewViewManager.kt
+++ b/android/src/main/java/com/reactnativepagerview/PagerViewViewManager.kt
@@ -13,9 +13,9 @@ import com.facebook.react.uimanager.PixelUtil
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.UIManagerModule
 import com.facebook.react.uimanager.ViewGroupManager
-import com.facebook.react.uimanager.UIManagerHelper
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.uimanager.events.EventDispatcher
+import com.reactnativepagerview.Helper.Companion.getReactContext
 import com.reactnativepagerview.event.PageScrollEvent
 import com.reactnativepagerview.event.PageScrollStateChangedEvent
 import com.reactnativepagerview.event.PageSelectedEvent
@@ -82,7 +82,7 @@ class PagerViewViewManager : ViewGroupManager<ViewPager2>() {
 
   override fun onDropViewInstance(view: ViewPager2) {
     super.onDropViewInstance(view)
-    UIManagerHelper.getReactContext(view).removeLifecycleEventListener(lifecycleEventListener);
+    getReactContext(view)?.removeLifecycleEventListener(lifecycleEventListener)
   }
 
   private fun setCurrentItem(view: ViewPager2, selectedTab: Int, scrollSmooth: Boolean) {


### PR DESCRIPTION
# Summary
Closes #394 

`getReactContext` method is missing in the older versions of react native. Moved this [method](https://github.com/facebook/react-native/blob/v0.64.2/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerHelper.java#L138) to the codebase. 

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |


