### PR TITLE
fix: deducing rtl device setup

### DIFF
--- a/android/src/main/java/com/reactnativepagerview/PagerViewViewManager.kt
+++ b/android/src/main/java/com/reactnativepagerview/PagerViewViewManager.kt
@@ -171,14 +171,8 @@ class PagerViewViewManager : ViewGroupManager<ViewPager2>() {
       "rtl" -> {
         viewPager.layoutDirection = View.LAYOUT_DIRECTION_RTL
       }
-      "ltr" -> {
-        viewPager.layoutDirection = View.LAYOUT_DIRECTION_LTR
-      }
-      "locale" -> {
-        viewPager.layoutDirection = View.LAYOUT_DIRECTION_LOCALE
-      }
       else -> {
-        viewPager.layoutDirection = View.LAYOUT_DIRECTION_INHERIT
+        viewPager.layoutDirection = View.LAYOUT_DIRECTION_LTR
       }
     }
   }

--- a/ios/ReactNativePageView.m
+++ b/ios/ReactNativePageView.m
@@ -437,10 +437,6 @@
 }
 
 - (BOOL)isLtrLayout {
-    if ([_layoutDirection isEqualToString:@"locale"]) {
-        return [UIApplication sharedApplication].userInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionLeftToRight;
-    } else {
-        return [_layoutDirection isEqualToString:@"ltr"];
-    }
+    return [_layoutDirection isEqualToString:@"ltr"];
 }
 @end

--- a/src/PagerView.tsx
+++ b/src/PagerView.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 import { Platform, UIManager, Keyboard } from 'react-native';
-import ReactNative from 'react-native';
+import ReactNative, { I18nManager } from 'react-native';
 import type {
   PagerViewOnPageScrollEvent,
   PagerViewOnPageSelectedEvent,
@@ -147,12 +147,24 @@ export class PagerView extends React.Component<PagerViewProps> {
     return this.isScrolling;
   };
 
+  private get deducedLayoutDirection() {
+    const shouldUseDeviceRtlSetup =
+      !this.props.layoutDirection || this.props.layoutDirection === 'locale';
+
+    if (shouldUseDeviceRtlSetup) {
+      return I18nManager.isRTL ? 'rtl' : 'ltr';
+    } else {
+      return this.props.layoutDirection;
+    }
+  }
+
   render() {
     return (
       <PagerViewViewManager
         {...this.props}
         ref={this.PagerView as any /** TODO: Fix ref type */}
         style={this.props.style}
+        layoutDirection={this.deducedLayoutDirection}
         onPageScroll={this._onPageScroll}
         onPageScrollStateChanged={this._onPageScrollStateChanged}
         onPageSelected={this._onPageSelected}


### PR DESCRIPTION
# Summary

Closes #367

When `layoutDirection` was `locale` or `undefined`, device RTL was incorrectly deduced.
Solution was to move the detection from native part to the `react-native` part, using `I18Manager.isRTL` property. Now it should better and more consistently recognise device RTL setup.

## Test Plan

### What's required for testing (prerequisites)?

Open PagerView with `layoutDirection="locale"` or with `layoutDirection` undefined.
Set `I18nManager.forceRTL(true)` to use RTL layout for the app.

### What are the steps to reproduce (after prerequisites)?

Open the pager and see layout is deduced from the app setup and the pager uses `RTL` layout by default.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
