### PR TITLE
fix(android): set initial page natively

### DIFF
--- a/android/src/main/java/com/reactnativepagerview/PagerViewViewManager.kt
+++ b/android/src/main/java/com/reactnativepagerview/PagerViewViewManager.kt
@@ -52,31 +52,37 @@ class PagerViewViewManager : ViewGroupManager<ViewPager2>() {
     //https://github.com/callstack/react-native-viewpager/issues/183
     vp.isSaveEnabled = false
     eventDispatcher = reactContext.getNativeModule(UIManagerModule::class.java)!!.eventDispatcher
-    vp.registerOnPageChangeCallback(object : OnPageChangeCallback() {
-      override fun onPageScrolled(position: Int, positionOffset: Float, positionOffsetPixels: Int) {
-        super.onPageScrolled(position, positionOffset, positionOffsetPixels)
-        eventDispatcher.dispatchEvent(
-          PageScrollEvent(vp.id, position, positionOffset))
-      }
 
-      override fun onPageSelected(position: Int) {
-        super.onPageSelected(position)
-        eventDispatcher.dispatchEvent(
-          PageSelectedEvent(vp.id, position))
-      }
-
-      override fun onPageScrollStateChanged(state: Int) {
-        super.onPageScrollStateChanged(state)
-        val pageScrollState: String = when (state) {
-          ViewPager2.SCROLL_STATE_IDLE -> "idle"
-          ViewPager2.SCROLL_STATE_DRAGGING -> "dragging"
-          ViewPager2.SCROLL_STATE_SETTLING -> "settling"
-          else -> throw IllegalStateException("Unsupported pageScrollState")
+    vp.post {
+      vp.registerOnPageChangeCallback(object : OnPageChangeCallback() {
+        override fun onPageScrolled(position: Int, positionOffset: Float, positionOffsetPixels: Int) {
+          super.onPageScrolled(position, positionOffset, positionOffsetPixels)
+          eventDispatcher.dispatchEvent(
+                  PageScrollEvent(vp.id, position, positionOffset))
         }
-        eventDispatcher.dispatchEvent(
-          PageScrollStateChangedEvent(vp.id, pageScrollState))
-      }
-    })
+
+        override fun onPageSelected(position: Int) {
+          super.onPageSelected(position)
+          eventDispatcher.dispatchEvent(
+                  PageSelectedEvent(vp.id, position))
+        }
+
+        override fun onPageScrollStateChanged(state: Int) {
+          super.onPageScrollStateChanged(state)
+          val pageScrollState: String = when (state) {
+            ViewPager2.SCROLL_STATE_IDLE -> "idle"
+            ViewPager2.SCROLL_STATE_DRAGGING -> "dragging"
+            ViewPager2.SCROLL_STATE_SETTLING -> "settling"
+            else -> throw IllegalStateException("Unsupported pageScrollState")
+          }
+          eventDispatcher.dispatchEvent(
+                  PageScrollStateChangedEvent(vp.id, pageScrollState))
+        }
+      })
+
+      eventDispatcher.dispatchEvent(PageSelectedEvent(vp.id, vp.currentItem))
+    }
+
     return vp
   }
 
@@ -137,6 +143,13 @@ class PagerViewViewManager : ViewGroupManager<ViewPager2>() {
   @ReactProp(name = "scrollEnabled", defaultBoolean = true)
   fun setScrollEnabled(viewPager: ViewPager2, value: Boolean) {
     viewPager.isUserInputEnabled = value
+  }
+
+  @ReactProp(name = "initialPage", defaultInt = 0)
+  fun setInitialPage(viewPager: ViewPager2, value: Int) {
+    viewPager.post {
+      setCurrentItem(viewPager, value, false)
+    }
   }
 
   @ReactProp(name = "orientation")

--- a/src/PagerView.tsx
+++ b/src/PagerView.tsx
@@ -55,25 +55,7 @@ import { getViewManagerConfig, PagerViewViewManager } from './PagerViewNative';
 
 export class PagerView extends React.Component<PagerViewProps> {
   private isScrolling = false;
-  private animationFrameRequestId?: number;
   private PagerView = React.createRef<typeof PagerViewViewManager>();
-
-  componentWillUnmount() {
-    if (this.animationFrameRequestId !== undefined) {
-      cancelAnimationFrame(this.animationFrameRequestId);
-    }
-  }
-
-  componentDidMount() {
-    // On iOS we do it directly on the native side
-    if (Platform.OS === 'android' && this.props.initialPage !== undefined) {
-      this.animationFrameRequestId = requestAnimationFrame(() => {
-        if (this.props.initialPage !== undefined) {
-          this.setPageWithoutAnimation(this.props.initialPage);
-        }
-      });
-    }
-  }
 
   public getInnerViewNode = (): ReactElement => {
     return this.PagerView.current!.getInnerViewNode();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Closes #400

On Android, setting initial page was implemented asynchronously on React side and native `onPageSelected` was fired twice (with default value and then with proper one).
This PR moves the implementation directly to `ViewPager2` API.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

Setup `Basic Example` with `initialPage={1}` and with `onPageSelected={(e: any) => console.log(e.nativeEvent.position)}`

### What are the steps to reproduce (after prerequisites)?

Open the Example and see what pages are reported in `onPageSelected` callback

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
