### PR TITLE
fix: initially empty views

### DIFF
--- a/android/src/main/java/com/reactnativepagerview/PagerViewViewManager.kt
+++ b/android/src/main/java/com/reactnativepagerview/PagerViewViewManager.kt
@@ -95,6 +95,14 @@ class PagerViewViewManager : ViewGroupManager<ViewPager2>() {
       return
     }
     (parent.adapter as FragmentAdapter?)?.addFragment(child, index)
+
+    if (parent.currentItem == index) {
+      // Solves https://github.com/callstack/react-native-pager-view/issues/219
+      // Required so ViewPager actually displays first dynamically added child
+      // (otherwise a white screen is shown until the next user interaction).
+      // https://github.com/facebook/react-native/issues/17968#issuecomment-697136929
+      refreshViewChildrenLayout(parent)
+    }
   }
 
   override fun getChildCount(parent: ViewPager2): Int {

--- a/ios/ReactNativePageView.m
+++ b/ios/ReactNativePageView.m
@@ -198,11 +198,11 @@
 }
 
 - (void)updateDataSource {
-    if (!self.currentView) {
+    if (!self.currentView && self.reactSubviews.count == 0) {
         return;
     }
     
-    NSInteger newIndex = [self.reactSubviews indexOfObject:self.currentView];
+    NSInteger newIndex = self.currentView ? [self.reactSubviews indexOfObject:self.currentView] : 0;
     
     if (newIndex == NSNotFound) {
         // Current view was removed


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Closes #219

Both iOS and Android implementations had issues when the `PagerView` was initially rendered with empty pages set.
Android: blank page was rendered, proper page appeared after user's first interaction
iOS: blank page was rendered, it didnt appear even after first interaction

This PR fixes handling initially empty sets on both platforms.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

Render pager with empty pages initially set and add more pages on the fly.
See pages are now rendered correctly.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
