### PR TITLE
fix setPage call to long

### DIFF
--- a/src/LazyPagerView.tsx
+++ b/src/LazyPagerView.tsx
@@ -154,7 +154,7 @@ class LazyPagerViewImpl<ItemT> extends React.Component<
       })
     );
     // Send paging command.
-    setTimeout(() => {
+    setImmediate(() => {
       UIManager.dispatchViewManagerCommand(
         findNodeHandle(this),
         animated
@@ -162,7 +162,7 @@ class LazyPagerViewImpl<ItemT> extends React.Component<
           : getViewManagerConfig().Commands.setPageWithoutAnimation,
         [page]
       );
-    }, 0);
+    });
   }
 
   /**

--- a/src/LazyPagerView.tsx
+++ b/src/LazyPagerView.tsx
@@ -154,7 +154,7 @@ class LazyPagerViewImpl<ItemT> extends React.Component<
       })
     );
     // Send paging command.
-    requestAnimationFrame(() => {
+    setTimeout(() => {
       UIManager.dispatchViewManagerCommand(
         findNodeHandle(this),
         animated
@@ -162,7 +162,7 @@ class LazyPagerViewImpl<ItemT> extends React.Component<
           : getViewManagerConfig().Commands.setPageWithoutAnimation,
         [page]
       );
-    });
+    }, 0);
   }
 
   /**


### PR DESCRIPTION
### *It's too long when call setPage method if is running other animation.*

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
It's too long when call `setPage` method if is running other animation. I thought its waiting for other animation frame. So, I tried change`requestAnimationFrame` to `setTimeout`.
It looks smoother.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅   |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [x] I updated the typed files (TS and Flow)
