### PR TITLE
chore(android): prioritize mavenCentral over jcenter

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,6 +4,7 @@ buildscript {
 
   repositories {
     google()
+    mavenCentral()
     jcenter()
   }
 

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -9,6 +9,7 @@ buildscript {
     }
     repositories {
         google()
+        mavenCentral()
         jcenter()
     }
     dependencies {
@@ -35,6 +36,7 @@ allprojects {
             url "$rootDir/../node_modules/detox/Detox-android"
         }
         google()
+        mavenCentral()
         jcenter()
         maven { url 'https://www.jitpack.io' }
     }


### PR DESCRIPTION
# Summary

Recent react-native dependencies are published to Maven Central only.

https://github.com/react-native-camera/react-native-camera/issues/2490