### PR TITLE
fix(ios): multiple onPageSelected calling

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -185,7 +185,7 @@ PODS:
     - React-cxxreact (= 0.63.4)
     - React-jsi (= 0.63.4)
   - React-jsinspector (0.63.4)
-  - react-native-pager-view (5.2.1):
+  - react-native-pager-view (5.4.4):
     - React-Core
   - react-native-safe-area-context (3.2.0):
     - React-Core
@@ -382,7 +382,7 @@ SPEC CHECKSUMS:
   React-jsi: a0418934cf48f25b485631deb27c64dc40fb4c31
   React-jsiexecutor: 93bd528844ad21dc07aab1c67cb10abae6df6949
   React-jsinspector: 58aef7155bc9a9683f5b60b35eccea8722a4f53a
-  react-native-pager-view: 2864530d861ab2970beb2cd0b4cf2292cd30cd84
+  react-native-pager-view: 5ab4d0b4b44d89f77310cb3eb8129745f274ce55
   react-native-safe-area-context: f0906bf8bc9835ac9a9d3f97e8bde2a997d8da79
   React-RCTActionSheet: 89a0ca9f4a06c1f93c26067af074ccdce0f40336
   React-RCTAnimation: 1bde3ecc0c104c55df246eda516e0deb03c4e49b

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -44,6 +44,7 @@ function App() {
           key={example.name}
           style={styles.exampleTouchable}
           onPress={() => {
+            //@ts-ignore
             navigation.navigate(example.name);
           }}
         >

--- a/ios/ReactNativePageView.m
+++ b/ios/ReactNativePageView.m
@@ -159,14 +159,16 @@
         [self setReactViewControllers:self.initialPage
                                  with:initialController
                             direction:UIPageViewControllerNavigationDirectionForward
-                             animated:YES];
+                             animated:YES
+             shouldCallOnPageSelected:YES];
     }
 }
 
 - (void)setReactViewControllers:(NSInteger)index
                            with:(UIViewController *)controller
                       direction:(UIPageViewControllerNavigationDirection)direction
-                       animated:(BOOL)animated {
+                       animated:(BOOL)animated
+                       shouldCallOnPageSelected:(BOOL)shouldCallOnPageSelected {
     if (self.reactPageViewController == nil) {
         return;
     }
@@ -183,7 +185,9 @@
         
         if (strongSelf.eventDispatcher) {
             if (strongSelf.lastReportedIndex != strongSelf.currentIndex) {
-                [strongSelf.eventDispatcher sendEvent:[[RCTOnPageSelected alloc] initWithReactTag:strongSelf.reactTag position:@(index) coalescingKey:coalescingKey]];
+                if (shouldCallOnPageSelected) {
+                    [strongSelf.eventDispatcher sendEvent:[[RCTOnPageSelected alloc] initWithReactTag:strongSelf.reactTag position:@(index) coalescingKey:coalescingKey]];
+                }
                 strongSelf.lastReportedIndex = strongSelf.currentIndex;
             }
         }
@@ -236,33 +240,39 @@
     long diff = labs(index - _currentIndex);
     
     if (isForward && diff > 0) {
-        for (NSInteger i=_currentIndex+1; i<=index; i++) {
-            [self goToViewController:i direction:direction animated:animated];
+        for (NSInteger i=_currentIndex; i<=index; i++) {
+            if (i == _currentIndex) {
+                continue;
+            }
+            [self goToViewController:i direction:direction animated:animated shouldCallOnPageSelected: i == index];
         }
     }
     
     if (!isForward && diff > 0) {
-        for (NSInteger i=_currentIndex-1; i>=index; i--) {
-            if (i >=0) {
-                [self goToViewController:i direction:direction animated:animated];
+        for (NSInteger i=_currentIndex; i>=index; i--) {
+            if (index == _currentIndex) {
+                continue;
             }
+            [self goToViewController:i direction:direction animated:animated shouldCallOnPageSelected: i == index];
         }
     }
     
     if (diff == 0) {
-        [self goToViewController:index direction:direction animated:animated];
+        [self goToViewController:index direction:direction animated:animated shouldCallOnPageSelected:YES];
     }
 }
 
 - (void)goToViewController:(NSInteger)index
                             direction:(UIPageViewControllerNavigationDirection)direction
-                            animated:(BOOL)animated {
+                            animated:(BOOL)animated
+                            shouldCallOnPageSelected:(BOOL)shouldCallOnPageSelected {
     UIView *viewToDisplay = self.reactSubviews[index];
     UIViewController *controllerToDisplay = [self findAndCacheControllerForView:viewToDisplay];
     [self setReactViewControllers:index
                              with:controllerToDisplay
                         direction:direction
-                         animated:animated];
+                         animated:animated
+                        shouldCallOnPageSelected:shouldCallOnPageSelected];
 }
     
 - (UIViewController *)findAndCacheControllerForView:(UIView *)viewToDisplay {
@@ -320,7 +330,6 @@
         self.currentIndex = currentIndex;
         self.currentView = currentVC.view;
         self.reactPageIndicatorView.currentPage = currentIndex;
-        
         [self.eventDispatcher sendEvent:[[RCTOnPageSelected alloc] initWithReactTag:self.reactTag position:@(currentIndex) coalescingKey:_coalescingKey++]];
         [self.eventDispatcher sendEvent:[[RCTOnPageScrollEvent alloc] initWithReactTag:self.reactTag position:@(currentIndex) offset:@(0.0)]];
         self.lastReportedIndex = currentIndex;


### PR DESCRIPTION
# Summary

Closes #454 

`onPageSelected` fires for every page in between the range.

## Test Plan

https://user-images.githubusercontent.com/12766071/135571785-ab307ee7-18a3-4eda-8d53-9be45c64ffe1.mov

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |
