### PR TITLE
fix: update pager view only when layout changed

### DIFF
--- a/ios/ReactNativePageView.h
+++ b/ios/ReactNativePageView.h
@@ -23,6 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, copy) RCTDirectEventBlock onPageScrollStateChanged;
 @property(nonatomic) BOOL overdrag;
 @property(nonatomic) NSString* layoutDirection;
+@property(nonatomic) CGRect previousBounds;
 
 
 - (void)goTo:(NSInteger)index animated:(BOOL)animated;

--- a/ios/ReactNativePageView.m
+++ b/ios/ReactNativePageView.m
@@ -47,6 +47,7 @@
         _cachedControllers = [NSHashTable weakObjectsHashTable];
         _overdrag = NO;
         _layoutDirection = @"ltr";
+        _previousBounds = CGRectMake(0, 0, 0, 0);
     }
     return self;
 }
@@ -55,8 +56,13 @@
     [super layoutSubviews];
     if (self.reactPageViewController) {
         [self shouldScroll:self.scrollEnabled];
-        //Below line fix bug, where the view does not update after orientation changed.
-        [self updateDataSource];
+
+        if (!CGRectEqualToRect(self.previousBounds, CGRectMake(0, 0, 0, 0)) && !CGRectEqualToRect(self.bounds, self.previousBounds)) {
+            // Below line fix bug, where the view does not update after orientation changed.
+            [self updateDataSource];
+        }
+
+        self.previousBounds = CGRectMake(self.bounds.origin.x, self.bounds.origin.y, self.bounds.size.width, self.bounds.size.height);
     }
 }
 


### PR DESCRIPTION
# Summary

Currently we update the pager view in `layoutSubviews` method to make sure that our layout stays in sync. However, this method seems to get called even if the layout didn't change - and calling `updateDataSource` dismisses the keyboard if it's visible, This causes the keyboard to be dismissed when it's not supposed to - e.g. auto focus on input doesn't work, keyboard doesn't stay open when app goes to background etc.

This adds a check to make sure that we call `updateDataSourcez only if the layout changes, which avoids unnecessary updates and avoids dismissing the keyboard unnecessarily.

Fixes #441

## Test Plan

Open the example app in the repo, open the keyboard example and focus the text input. When the keyboard is visible, put the app in the background and then bring it to the foreground.

Without this patch, the keyboard won't be visible when it comes back to the foreground. But after this patch, the keyboard would stay visible.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅    |
| Android |   NA     |

## Checklist

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
