### PR TITLE
fix: prevent removing last page from crashing [ios]

### DIFF
--- a/ios/ReactNativePageView.m
+++ b/ios/ReactNativePageView.m
@@ -256,7 +256,7 @@
     
     if (!isForward && diff > 0) {
         for (NSInteger i=_currentIndex; i>=index; i--) {
-            if (index == _currentIndex) {
+            if (index == _currentIndex || i == numberOfPages) {
                 continue;
             }
             [self goToViewController:i direction:direction animated:animated shouldCallOnPageSelected: i == index];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Fixes #465 

From what I could understand is that #395 fixed a similar problem, but there was still a problem in the `goTo` method. The problem was calling `goToViewController` and passing an index that was previously removed caused iOS to crash.

This PR makes sure that for transitions that go backwards will check that it won't call `goToViewController` with those indexes.

I don't have much experience with iOS development, so if the fix should be something else, let me know!

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Running the example, navigate to last page and remove the last page should not crash.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    doesn't apply     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
