### PR TITLE
fix(ios) : when called multiple times in a row, the competion callback is not called

### DIFF
--- a/ios/ReactNativePageView.m
+++ b/ios/ReactNativePageView.m
@@ -174,7 +174,8 @@
     }
     __weak ReactNativePageView *weakSelf = self;
     uint16_t coalescingKey = _coalescingKey++;
-    animated = animated && self.reactPageViewController.viewControllers.firstObject != controller && shouldCallOnPageSelected; 
+    // fix(ios) : when called multiple times in a row, the competion callback is not called.
+    animated = animated && shouldCallOnPageSelected; 
     [self.reactPageViewController setViewControllers:@[controller]
                                            direction:direction
                                             animated:animated


### PR DESCRIPTION
Jumping directly from the first page to the last page will occasionally result in a white screen. And the onPageSelected method is not executed.


## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
