### PR TITLE
docs: update link to react native's view's collapsable docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ const styles = StyleSheet.create({
 ```
 
 **Attention:** Note that you can only use `View` components as children of `PagerView` (cf. folder _/example_)
-. For Android if `View` has own children, set prop `collapsable` to false <https://reactnative.dev/img/view#collapsable>, otherwise react-native might remove those children views and and it's children will be rendered as separate pages
+. For Android if `View` has own children, set prop `collapsable` to false <https://reactnative.dev/docs/view#collapsable-android>, otherwise react-native might remove those children views and and it's children will be rendered as separate pages
 
 ## Advanced usage
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

In the docs, the link after the "Usage" code snippet talks about setting collapsable to false and the link to the documentation on collapsable is broken. I've updated it to point to the proper resource.

## Test Plan

Click the link.

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ❌     |

## Checklist

- [ ] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
