### PR TITLE
fix crash in ios due to rapid tap on tab

### DIFF
--- a/ios/ReactNativePageView.h
+++ b/ios/ReactNativePageView.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic) BOOL overdrag;
 @property(nonatomic) NSString* layoutDirection;
 @property(nonatomic) CGRect previousBounds;
-
+@property(nonatomic) NSInteger numberOfAction;
 
 - (void)goTo:(NSInteger)index animated:(BOOL)animated;
 - (void)shouldScroll:(BOOL)scrollEnabled;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
This PR is related to this issue https://github.com/callstack/react-native-pager-view/issues/458. **(react-native-view-pager)** and https://github.com/satya164/react-native-tab-view/issues/1277 **(react-native-tab-view)**.  IOS App Crash due to Rapid Tap on Tab Navigation. This issue seems due to racing conditions of animation. So in this PR I solve the issue by counting the tap action and only allowing new action when all existing actions are completed. 

## Test Plan

### What's required for testing (prerequisites)?
1. https://github.com/satya164/react-native-tab-view

### What are the steps to reproduce (after prerequisites)?
1. Create Tab Navigation (I this case I'm using https://github.com/satya164/react-native-tab-view)
2. Rapid tap on "Tab" Navigation.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅    |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- ✅ I have tested this on a device and a simulator

