### PR TITLE
Prevent 1 frame flicker on android if initialPage != 0

### DIFF
--- a/android/src/main/java/com/reactnativepagerview/NestedScrollableHost.kt
+++ b/android/src/main/java/com/reactnativepagerview/NestedScrollableHost.kt
@@ -23,6 +23,7 @@ class NestedScrollableHost : FrameLayout {
   constructor(context: Context) : super(context)
   constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
   public var initialIndex: Int? = null
+  public var didSetInitialIndex = false
   private var touchSlop = 0
   private var initialX = 0f
   private var initialY = 0f

--- a/android/src/main/java/com/reactnativepagerview/PagerViewViewManager.kt
+++ b/android/src/main/java/com/reactnativepagerview/PagerViewViewManager.kt
@@ -96,6 +96,11 @@ class PagerViewViewManager : ViewGroupManager<NestedScrollableHost>() {
       // https://github.com/facebook/react-native/issues/17968#issuecomment-697136929
       refreshViewChildrenLayout(parent)
     }
+
+    if (!host.didSetInitialIndex && host.initialIndex == index) {
+      host.didSetInitialIndex = true
+      setCurrentItem(parent, index, false)
+    }
   }
 
   override fun getChildCount(parent: NestedScrollableHost) = getViewPager(parent).adapter?.itemCount ?: 0
@@ -148,9 +153,9 @@ class PagerViewViewManager : ViewGroupManager<NestedScrollableHost>() {
     //https://github.com/callstack/react-native-pager-view/issues/456
     //Initial index should be set only once. 
     if (host.initialIndex === null) {
+      host.initialIndex = value
       view.post {
-        setCurrentItem(view, value, false)
-        host.initialIndex = value
+        host.didSetInitialIndex = true
       }
     }
   }


### PR DESCRIPTION
# Summary

Whenever using initialPage != 0 on Android there is a 1 frame flicker where you can see the page at index 0 displayed before the right page at initialPage is displayed. This happens because the setting of the initial page is delayed in https://github.com/callstack/react-native-pager-view/blob/master/android/src/main/java/com/reactnativepagerview/PagerViewViewManager.kt#L151
To compensate for not knowing (due to a limitation in rn) how many children are initially added, this also tracks that initial page is only set in the initial render.

## Test Plan

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

Use a PagerView with initialPage != 0 and record the render. Step through the video frame by frame, you will see it jumping on first render.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Android |    ✅    |

## Checklist

- [x] I have tested this on a device and a simulator
