### PR TITLE
fix(ios): Crash when rapidly switching pages

### DIFF
--- a/ios/ReactNativePageView.h
+++ b/ios/ReactNativePageView.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic) BOOL overdrag;
 @property(nonatomic) NSString* layoutDirection;
 @property(nonatomic) CGRect previousBounds;
-
+@property(nonatomic, assign) BOOL animating;
 
 - (void)goTo:(NSInteger)index animated:(BOOL)animated;
 - (void)shouldScroll:(BOOL)scrollEnabled;

--- a/ios/ReactNativePageView.m
+++ b/ios/ReactNativePageView.m
@@ -19,7 +19,7 @@
 @property(nonatomic, weak) UIView *currentView;
 
 @property(nonatomic, strong) NSHashTable<UIViewController *> *cachedControllers;
-@property (nonatomic, assign) CGPoint lastContentOffset;
+@property(nonatomic, assign) CGPoint lastContentOffset;
 
 - (void)goTo:(NSInteger)index animated:(BOOL)animated;
 - (void)shouldScroll:(BOOL)scrollEnabled;
@@ -181,6 +181,10 @@
     __weak ReactNativePageView *weakSelf = self;
     uint16_t coalescingKey = _coalescingKey++;
     
+    if (animated == YES) {
+        self.animating = YES;
+    }
+    
     [self.reactPageViewController setViewControllers:@[controller]
                                            direction:direction
                                             animated:animated
@@ -188,6 +192,10 @@
         __strong typeof(self) strongSelf = weakSelf;
         strongSelf.currentIndex = index;
         strongSelf.currentView = controller.view;
+        
+        if (finished) {
+            strongSelf.animating = NO;
+        }
         
         if (strongSelf.eventDispatcher) {
             if (strongSelf.lastReportedIndex != strongSelf.currentIndex) {

--- a/ios/ReactViewPagerManager.m
+++ b/ios/ReactViewPagerManager.m
@@ -31,7 +31,9 @@ RCT_EXPORT_VIEW_PROPERTY(layoutDirection, NSString)
             RCTLogError(@"Cannot find ReactNativePageView with tag #%@", reactTag);
             return;
         }
-        [view goTo:index.integerValue animated:animated];
+        if (!animated || !view.animating) {
+            [view goTo:index.integerValue animated:animated];
+        }
     }];
 }
 


### PR DESCRIPTION
# Summary

This PR resolves issue: https://github.com/callstack/react-native-pager-view/issues/458

Working demo of no crash when tab switching quickly:

https://user-images.githubusercontent.com/85892917/152933713-fc860143-46b6-4b91-9600-4441fc3171bf.mp4

## Test Plan

### What's required for testing (prerequisites)?

Use the example app.

### What are the steps to reproduce (after prerequisites)?

Switch back and forth between tabs super quickly and observe a crash.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

- [✅] I have tested this on a device and a simulator
