### PR TITLE
Return early when new view controller is the same as the old one

### DIFF
--- a/ios/ReactNativePageView.m
+++ b/ios/ReactNativePageView.m
@@ -178,6 +178,12 @@
     if (self.reactPageViewController == nil) {
         return;
     }
+
+    NSArray *currentVCs = self.reactPageViewController.viewControllers;
+    if (currentVCs.count == 1 && [currentVCs.firstObject isEqual:controller]) {
+        return;
+    }
+
     __weak ReactNativePageView *weakSelf = self;
     uint16_t coalescingKey = _coalescingKey++;
     


### PR DESCRIPTION
In case of setting UIPageViewController.viewControllers to exactly the same controllers, the completion block is not called.
With the introduction of animating in #510, animating will then not be set to NO anymore. 
This will lead to being unable to switch the pages.

# Summary

Fixes a regression in #510 
cc @doug-lessen

## Test Plan

Goto the same page without changing the view, after that switching the page is no longer possible.

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
