### PR TITLE
fix(ios): Updated index before animation

### DIFF
--- a/ios/ReactNativePageView.h
+++ b/ios/ReactNativePageView.h
@@ -12,6 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic) NSInteger initialPage;
 @property(nonatomic) NSInteger lastReportedIndex;
 @property(nonatomic) NSInteger currentIndex;
+@property(nonatomic) NSInteger destinationIndex;
 @property(nonatomic) NSInteger pageMargin;
 @property(nonatomic, readonly) BOOL scrollEnabled;
 @property(nonatomic, readonly) BOOL showPageIndicator;
@@ -24,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic) BOOL overdrag;
 @property(nonatomic) NSString* layoutDirection;
 @property(nonatomic) CGRect previousBounds;
-@property(nonatomic, assign) BOOL animating;
+@property(nonatomic, assign) BOOL inTransition;
 
 - (void)goTo:(NSInteger)index animated:(BOOL)animated;
 - (void)shouldScroll:(BOOL)scrollEnabled;

--- a/ios/ReactNativePageView.m
+++ b/ios/ReactNativePageView.m
@@ -185,13 +185,13 @@
         self.animating = YES;
     }
     
+    self.currentIndex = index;
+    self.currentView = controller.view;
     [self.reactPageViewController setViewControllers:@[controller]
                                            direction:direction
                                             animated:animated
                                           completion:^(BOOL finished) {
         __strong typeof(self) strongSelf = weakSelf;
-        strongSelf.currentIndex = index;
-        strongSelf.currentView = controller.view;
         
         if (finished) {
             strongSelf.animating = NO;

--- a/ios/ReactViewPagerManager.m
+++ b/ios/ReactViewPagerManager.m
@@ -31,9 +31,8 @@ RCT_EXPORT_VIEW_PROPERTY(layoutDirection, NSString)
             RCTLogError(@"Cannot find ReactNativePageView with tag #%@", reactTag);
             return;
         }
-        if (!animated || !view.animating) {
-            [view goTo:index.integerValue animated:animated];
-        }
+
+        [view goTo:index.integerValue animated:animated];
     }];
 }
 


### PR DESCRIPTION
# Summary
On iOS:

If setPage is called and the containing view changes size before animation finishes, the updateDataSource method will be called resetting the page to the preview page.

## Test Plan

I am unable to provide screenshots as the application is unreleased.

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

- [ x] I have tested this on a device and a simulator
- [x ] I added the documentation in `README.md`
- [x ] I updated the typed files (TS and Flow)
