### PR TITLE
fix(android): cannot set initialPage due to ViewPager2 bug

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,6 +47,10 @@ android {
     sourceCompatibility JavaVersion.VERSION_1_8
     targetCompatibility JavaVersion.VERSION_1_8
   }
+
+  kotlinOptions {
+    jvmTarget = JavaVersion.VERSION_1_8.toString()
+  }
 }
 
 repositories {
@@ -127,4 +131,5 @@ dependencies {
   api 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation 'androidx.viewpager2:viewpager2:1.0.0'
+  implementation "androidx.core:core-ktx:1.6.0"
 }

--- a/android/src/main/java/com/reactnativepagerview/PagerViewViewManager.kt
+++ b/android/src/main/java/com/reactnativepagerview/PagerViewViewManager.kt
@@ -2,6 +2,7 @@ package com.reactnativepagerview
 
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.doOnLayout
 import androidx.viewpager2.widget.ViewPager2
 import androidx.viewpager2.widget.ViewPager2.OnPageChangeCallback
 import com.facebook.infer.annotation.Assertions
@@ -148,7 +149,7 @@ class PagerViewViewManager : ViewGroupManager<NestedScrollableHost>() {
     //https://github.com/callstack/react-native-pager-view/issues/456
     //Initial index should be set only once. 
     if (host.initialIndex === null) {
-      view.post {
+      view.doOnLayout {
         setCurrentItem(view, value, false)
         host.initialIndex = value
       }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->
On ViewPager2 Android Library has a bug that cannot setCurrentItem at the time function setInitialPage was called (https://stackoverflow.com/questions/56311862/viewpager2-default-position). So, I tried to call setInitialPage when the view was attached to the window to make sure that call setCurrentItem will work normally.
What did I try?
 - Using view.post {} (default) --> sometime it's work, sometime it's not. And when I check isAttachedToWindow sometime return false.
 - Using view.doOnAttach {} --> same like view.post, even when isAttachedToWindow return true.
 - Using view.doOnLayout {} --> works as expected. No need to use hacky solution.
 - Using view.postDelayed {} with 200ms --> Worked. But it's a hacky solution and it doesn't reliable due. And UX is not good ( it was focused on the first page, then focus on the page that was set in initialPage props.
## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
- set intialPage props = 1 in [example](https://github.com/callstack/react-native-pager-view/blob/master/example/src/PaginationDotsExample.tsx)
- use Android emulator and start the app. The bug will randomly occur. (Due to lack of time, I cannot create a template or bug videos)
### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
