### PR TITLE
Do not redisplay currentview if not needed

### DIFF
--- a/ios/ReactNativePageView.m
+++ b/ios/ReactNativePageView.m
@@ -166,7 +166,8 @@
                                  with:initialController
                             direction:UIPageViewControllerNavigationDirectionForward
                              animated:YES
-             shouldCallOnPageSelected:YES];
+             shouldCallOnPageSelected:YES
+                          forceRedraw:YES];
     }
 }
 
@@ -174,10 +175,17 @@
                            with:(UIViewController *)controller
                       direction:(UIPageViewControllerNavigationDirection)direction
                        animated:(BOOL)animated
-                       shouldCallOnPageSelected:(BOOL)shouldCallOnPageSelected {
+                       shouldCallOnPageSelected:(BOOL)shouldCallOnPageSelected
+                    forceRedraw:(BOOL)forceRedraw {
     if (self.reactPageViewController == nil) {
         return;
     }
+  
+    // Don't redraw the currently displayed view controller unless forced
+    if (!forceRedraw && controller == self.currentlyDisplayed) {
+        return;
+    }
+  
     __weak ReactNativePageView *weakSelf = self;
     uint16_t coalescingKey = _coalescingKey++;
     
@@ -235,11 +243,15 @@
         
         [self goTo:fallbackIndex animated:NO];
     } else {
-        [self goTo:newIndex animated:NO];
+        [self goTo:newIndex animated:NO forceRedraw: YES];
     }
 }
 
 - (void)goTo:(NSInteger)index animated:(BOOL)animated {
+    [self goTo:index animated:animated forceRedraw:false];
+}
+
+- (void)goTo:(NSInteger)index animated:(BOOL)animated forceRedraw:(BOOL)forceRedraw {
     NSInteger numberOfPages = self.reactSubviews.count;
     
     if (numberOfPages == 0 || index < 0 || index > numberOfPages - 1) {
@@ -258,7 +270,7 @@
             if (i == _currentIndex) {
                 continue;
             }
-            [self goToViewController:i direction:direction animated:animated shouldCallOnPageSelected: i == index];
+            [self goToViewController:i direction:direction animated:animated shouldCallOnPageSelected: i == index forceRedraw:NO];
         }
     }
     
@@ -268,26 +280,28 @@
             if (i == _currentIndex || i >= numberOfPages) {
                 continue;
             }
-            [self goToViewController:i direction:direction animated:animated shouldCallOnPageSelected: i == index];
+            [self goToViewController:i direction:direction animated:animated shouldCallOnPageSelected: i == index forceRedraw:NO];
         }
     }
     
     if (diff == 0) {
-        [self goToViewController:index direction:direction animated:animated shouldCallOnPageSelected:YES];
+        [self goToViewController:index direction:direction animated:animated shouldCallOnPageSelected:YES forceRedraw: forceRedraw];
     }
 }
 
 - (void)goToViewController:(NSInteger)index
                             direction:(UIPageViewControllerNavigationDirection)direction
                             animated:(BOOL)animated
-                            shouldCallOnPageSelected:(BOOL)shouldCallOnPageSelected {
+                            shouldCallOnPageSelected:(BOOL)shouldCallOnPageSelected
+                            forceRedraw:(BOOL)forceRedraw{
     UIView *viewToDisplay = self.reactSubviews[index];
     UIViewController *controllerToDisplay = [self findAndCacheControllerForView:viewToDisplay];
     [self setReactViewControllers:index
                              with:controllerToDisplay
                         direction:direction
                          animated:animated
-                        shouldCallOnPageSelected:shouldCallOnPageSelected];
+                        shouldCallOnPageSelected:shouldCallOnPageSelected
+                      forceRedraw:forceRedraw];
 }
     
 - (UIViewController *)findAndCacheControllerForView:(UIView *)viewToDisplay {


### PR DESCRIPTION
# Summary

iOS First Responder was being lost when React Native was calling goTo on prop change. If goTo is called and the destination page is shown, do not redraw unless it is forced by a layout change.

## Test Plan

### What's required for testing (prerequisites)?
Have a page with a text field. When the text field is changed, cause the parent to be redrawn with the same page index (causing a goTo to be called). Previously, the first responder would be lost due to the redraw.

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

- [ x] I have tested this on a device and a simulator
- [x ] I added the documentation in `README.md`
- [x ] I updated the typed files (TS and Flow)
