### PR TITLE
fix(ios): executing the same setPage does not trigger the goTo method.

### DIFF
--- a/ios/ReactViewPagerManager.m
+++ b/ios/ReactViewPagerManager.m
@@ -31,9 +31,7 @@ RCT_EXPORT_VIEW_PROPERTY(layoutDirection, NSString)
             RCTLogError(@"Cannot find ReactNativePageView with tag #%@", reactTag);
             return;
         }
-        if (!animated || !view.animating) {
-            [view goTo:index.integerValue animated:animated];
-        }
+        [view goTo:index.integerValue animated:animated];
     }];
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
This is to fix https://github.com/satya164/react-native-tab-view/issues/1322 issue.
When you trigger setPage method more than two times, `view.animating` always False, so the goTo method is not triggered.
I know the last version solved the problem of multiple taps causing crush, but I think this judgment is redundant.
<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan
I tested the Iphone 13, It's work well!
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?
When you trigger setPage method more than two times


### What are the steps to reproduce (after prerequisites)?
See: https://github.com/chshanovskiy/tabview/blob/develop/tabview.gif

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅    |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
