### PR TITLE
Fixed potential blocking of the navigation

### DIFF
--- a/ios/ReactNativePageView.m
+++ b/ios/ReactNativePageView.m
@@ -184,10 +184,17 @@
     if (animated == YES) {
         self.animating = YES;
     }
+
+    //
+    // If 'controller' is the current visible controller and the 'animated' flag is set to YES,
+    // then 'setViewControllers' is called without invoking the completion handler. This can block the navigation from working.
+    // So we need to check if that would be the case, and if so, we will not perform animation.
+    //
+    BOOL canAnimate = (controller != [[self.reactPageViewController viewControllers] firstObject] );
     
     [self.reactPageViewController setViewControllers:@[controller]
                                            direction:direction
-                                            animated:animated
+                                            animated:canAnimate?animated:NO
                                           completion:^(BOOL finished) {
         __strong typeof(self) strongSelf = weakSelf;
         strongSelf.currentIndex = index;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

This PR is a better fix for the following problem. https://github.com/callstack/react-native-pager-view/issues/515. 

The rapid tap causes the setViewControllers function in UIPageViewController to not execute the completion block. When the completion block is not executed, the pager view gets in an invalid state and blocks any attempts to set a different page.

In this fix there is an extra check wether the controller that is set, is the same that is already in the UIPageViewController. If so, no animation is done and the completion block is executed. This makes sure that the completion block is always executed.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅    |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
