### PR TITLE
fix: animated set page may stick or overshoot

### DIFF
--- a/src/LazyPagerView.tsx
+++ b/src/LazyPagerView.tsx
@@ -143,6 +143,17 @@ class LazyPagerViewImpl<ItemT> extends React.Component<
       return;
     }
 
+    // Send paging command.
+    setTimeout(() => {
+      UIManager.dispatchViewManagerCommand(
+        findNodeHandle(this),
+        animated
+          ? getViewManagerConfig().Commands.setPage
+          : getViewManagerConfig().Commands.setPageWithoutAnimation,
+        [page]
+      );
+    }, 0);
+
     // Start rendering the destination.
     this.setState((prevState) =>
       this.computeRenderWindow({
@@ -153,16 +164,6 @@ class LazyPagerViewImpl<ItemT> extends React.Component<
         windowLength: prevState.windowLength,
       })
     );
-    // Send paging command.
-    setImmediate(() => {
-      UIManager.dispatchViewManagerCommand(
-        findNodeHandle(this),
-        animated
-          ? getViewManagerConfig().Commands.setPage
-          : getViewManagerConfig().Commands.setPageWithoutAnimation,
-        [page]
-      );
-    });
   }
 
   /**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->
Animated programmatic page changes when the viewer has a small `maxRenderWindow` may fail to change pages (observed most on iOS), or scroll past then back (observed most on Android).

Fixes #537

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

In the example project `LazyPagerViewExample.tsx`, reduce `maxRenderWindow` to 5.  With animations enabled, use the next button.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
