### PR TITLE
Only remove child view if it exists

### DIFF
--- a/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt
+++ b/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt
@@ -44,7 +44,10 @@ class ViewPagerAdapter() : Adapter<ViewPagerViewHolder>() {
 
   fun removeChild(child: View) {
     val index = childrenViews.indexOf(child)
-    removeChildAt(index)
+    
+    if(index > -1) {
+      removeChildAt(index)
+    }
   }
 
   fun removeAll() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

This PR simply only removes a child view if its index exists in the view list.

In our case, a page was unmounting that contained a list of reanimated views that had layout animations on them. It appears Reanimated was removing them first causing the pager view to crash when it attempted to remove a child that no longer existed. Removing the layout animations also resolved the issue but that is less than ideal.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What are the steps to reproduce (after prerequisites)?
Use a pagerview that contains children reanimated views that have an entering or exit animation prop. Unmount the root page they are in and this crash will occur:
![20220509_131658](https://user-images.githubusercontent.com/32551245/167481868-e60d13bd-e4ca-49c8-a40a-4eb1812edc12.jpg)




## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
