### PR TITLE
fix(ios): restore animated param check

### DIFF
--- a/ios/ReactNativePageView.m
+++ b/ios/ReactNativePageView.m
@@ -275,7 +275,7 @@
             if (i == _currentIndex) {
                 continue;
             }
-            [self goToViewController:i direction:direction animated:(!self.animating && i == index) shouldCallOnPageSelected: i == index];
+            [self goToViewController:i direction:direction animated:(!self.animating && i == index && animated) shouldCallOnPageSelected: i == index];
         }
     }
     
@@ -285,7 +285,7 @@
             if (i == _currentIndex || i >= numberOfPages) {
                 continue;
             }
-            [self goToViewController:i direction:direction animated:(!self.animating && i == index) shouldCallOnPageSelected: i == index];
+            [self goToViewController:i direction:direction animated:(!self.animating && i == index && animated) shouldCallOnPageSelected: i == index];
         }
     }
     


### PR DESCRIPTION
# Summary

Fix for #568 

## Test Plan

Before fix calling setPageWithoutAnimation starts transition to new page with animation (incorrect).
After fix there is no animation (correct).

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |

## Checklist

- [ x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
