### PR TITLE
fix(ios): incorrect pager height

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -185,9 +185,9 @@ PODS:
     - React-cxxreact (= 0.63.4)
     - React-jsi (= 0.63.4)
   - React-jsinspector (0.63.4)
-  - react-native-pager-view (5.4.23):
+  - react-native-pager-view (5.4.24):
     - React-Core
-  - react-native-safe-area-context (3.2.0):
+  - react-native-safe-area-context (3.4.1):
     - React-Core
   - React-RCTActionSheet (0.63.4):
     - React-Core/RCTActionSheetHeaders (= 0.63.4)
@@ -249,11 +249,11 @@ PODS:
     - React-Core (= 0.63.4)
     - React-cxxreact (= 0.63.4)
     - React-jsi (= 0.63.4)
-  - RNCMaskedView (0.1.10):
+  - RNCMaskedView (0.1.11):
     - React
   - RNGestureHandler (1.10.3):
     - React-Core
-  - RNReanimated (2.3.1):
+  - RNReanimated (2.8.0):
     - DoubleConversion
     - FBLazyVector
     - FBReactNativeSpec
@@ -261,7 +261,6 @@ PODS:
     - glog
     - RCTRequired
     - RCTTypeSafety
-    - React
     - React-callinvoker
     - React-Core
     - React-Core/DevSupport
@@ -281,8 +280,9 @@ PODS:
     - React-RCTText
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNScreens (2.18.1):
+  - RNScreens (3.13.1):
     - React-Core
+    - React-RCTImage
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -408,8 +408,8 @@ SPEC CHECKSUMS:
   React-jsi: a0418934cf48f25b485631deb27c64dc40fb4c31
   React-jsiexecutor: 93bd528844ad21dc07aab1c67cb10abae6df6949
   React-jsinspector: 58aef7155bc9a9683f5b60b35eccea8722a4f53a
-  react-native-pager-view: f7c878676230561d3ab6408d7fecaa410dd58264
-  react-native-safe-area-context: f0906bf8bc9835ac9a9d3f97e8bde2a997d8da79
+  react-native-pager-view: 95d0418c3c74279840abec6926653d32447bafb6
+  react-native-safe-area-context: 9e40fb181dac02619414ba1294d6c2a807056ab9
   React-RCTActionSheet: 89a0ca9f4a06c1f93c26067af074ccdce0f40336
   React-RCTAnimation: 1bde3ecc0c104c55df246eda516e0deb03c4e49b
   React-RCTBlob: a97d378b527740cc667e03ebfa183a75231ab0f0
@@ -420,10 +420,10 @@ SPEC CHECKSUMS:
   React-RCTText: 5c51df3f08cb9dedc6e790161195d12bac06101c
   React-RCTVibration: ae4f914cfe8de7d4de95ae1ea6cc8f6315d73d9d
   ReactCommon: 73d79c7039f473b76db6ff7c6b159c478acbbb3b
-  RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
+  RNCMaskedView: 0e1bc4bfa8365eba5fbbb71e07fbdc0555249489
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
-  RNReanimated: 5b5df752f76020971549cb57aa6371dac6895b9e
-  RNScreens: f7ad633b2e0190b77b6a7aab7f914fad6f198d8d
+  RNReanimated: 65989f9ee4f06e8e699e94ae855faf8e4e630216
+  RNScreens: 40a2cb40a02a609938137a1e0acfbf8fc9eebf19
   Yoga: 4bd86afe9883422a7c4028c00e34790f560923d6
 
 PODFILE CHECKSUM: ff595481d97548cf6367f753d945ef2a7fc1f818

--- a/example/src/KeyboardExample.tsx
+++ b/example/src/KeyboardExample.tsx
@@ -9,6 +9,7 @@ import {
   TextInput,
   Button,
   Animated,
+  KeyboardAvoidingView,
 } from 'react-native';
 import { Colors } from 'react-native/Libraries/NewAppScreen';
 import PagerView from 'react-native-pager-view';
@@ -40,49 +41,51 @@ export function KeyboardExample() {
   const { ref, ...navigationPanel } = useNavigationPanel(2);
   const { setPage } = navigationPanel;
   return (
-    <SafeAreaView style={styles.flex}>
-      <ScrollView contentContainerStyle={styles.flex} style={styles.flex}>
-        <View style={styles.logoContainer}>
-          <Image
-            style={styles.logo}
-            source={{
-              uri: logoUrl,
-            }}
-          />
-        </View>
-        <View style={styles.flex}>
-          <AnimatedPagerView
-            {...navigationPanel}
-            ref={ref}
-            style={styles.flex}
-            initialPage={0}
-            scrollEnabled={false}
-          >
-            <View style={styles.sectionContainer}>
-              <Page
-                title="First Question"
-                description="What is your favourite lib ?"
-                onPress={useCallback(() => setPage(1), [setPage])}
-                buttonTitle="Go to next question"
-              />
-            </View>
-            <View style={styles.sectionContainer}>
-              <Page
-                title="Second Question"
-                description="Why Pager View?"
-                onPress={useCallback(() => setPage(0), [setPage])}
-                buttonTitle="Go to previous question"
-              />
-            </View>
-          </AnimatedPagerView>
-        </View>
-      </ScrollView>
-      <NavigationPanel
-        {...navigationPanel}
-        scrollEnabled={false}
-        disablePagesAmountManagement
-      />
-    </SafeAreaView>
+    <KeyboardAvoidingView style={styles.flex} behavior="height">
+      <SafeAreaView style={styles.flex}>
+        <ScrollView contentContainerStyle={styles.flex} style={styles.flex}>
+          <View style={styles.logoContainer}>
+            <Image
+              style={styles.logo}
+              source={{
+                uri: logoUrl,
+              }}
+            />
+          </View>
+          <View style={styles.flex}>
+            <AnimatedPagerView
+              {...navigationPanel}
+              ref={ref}
+              style={styles.flex}
+              initialPage={0}
+              scrollEnabled={false}
+            >
+              <View style={styles.sectionContainer}>
+                <Page
+                  title="First Question"
+                  description="What is your favourite lib ?"
+                  onPress={useCallback(() => setPage(1), [setPage])}
+                  buttonTitle="Go to next question"
+                />
+              </View>
+              <View style={styles.sectionContainer}>
+                <Page
+                  title="Second Question"
+                  description="Why Pager View?"
+                  onPress={useCallback(() => setPage(0), [setPage])}
+                  buttonTitle="Go to previous question"
+                />
+              </View>
+            </AnimatedPagerView>
+          </View>
+        </ScrollView>
+        <NavigationPanel
+          {...navigationPanel}
+          scrollEnabled={false}
+          disablePagesAmountManagement
+        />
+      </SafeAreaView>
+    </KeyboardAvoidingView>
   );
 }
 

--- a/ios/ReactNativePageView.h
+++ b/ios/ReactNativePageView.h
@@ -23,7 +23,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, copy) RCTDirectEventBlock onPageScrollStateChanged;
 @property(nonatomic) BOOL overdrag;
 @property(nonatomic) NSString* layoutDirection;
-@property(nonatomic) CGRect previousBounds;
 @property(nonatomic, assign) BOOL animating;
 
 - (void)goTo:(NSInteger)index animated:(BOOL)animated;

--- a/ios/ReactNativePageView.m
+++ b/ios/ReactNativePageView.m
@@ -47,7 +47,6 @@
         _cachedControllers = [NSHashTable hashTableWithOptions:NSHashTableStrongMemory];
         _overdrag = NO;
         _layoutDirection = @"ltr";
-        _previousBounds = CGRectMake(0, 0, 0, 0);
     }
     return self;
 }
@@ -56,13 +55,6 @@
     [super layoutSubviews];
     if (self.reactPageViewController) {
         [self shouldScroll:self.scrollEnabled];
-
-        if (!CGRectEqualToRect(self.previousBounds, CGRectMake(0, 0, 0, 0)) && !CGRectEqualToRect(self.bounds, self.previousBounds)) {
-            // Below line fix bug, where the view does not update after orientation changed.
-            [self updateDataSource];
-        }
-
-        self.previousBounds = CGRectMake(self.bounds.origin.x, self.bounds.origin.y, self.bounds.size.width, self.bounds.size.height);
     }
 }
 
@@ -185,13 +177,6 @@
 
     NSArray *currentVCs = self.reactPageViewController.viewControllers;
     if (currentVCs.count == 1 && [currentVCs.firstObject isEqual:controller]) {
-        // see: 
-        // 1) https://github.com/callstack/react-native-pager-view/pull/462
-        // 2) https://github.com/callstack/react-native-pager-view/issues/566
-        [self.reactPageViewController setViewControllers:@[controller]
-                                               direction:direction
-                                                animated:YES
-                                              completion:nil];
         return;
     }
 

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -8,30 +8,21 @@
  * @flow strict-local
  */
 
-import React, { Children, ReactNode, ReactElement } from 'react';
+import React, { Children, ReactNode } from 'react';
+import { StyleSheet, View } from 'react-native';
 
 export const childrenWithOverriddenStyle = (children?: ReactNode) => {
-  // Override styles so that each page will fill the parent. Native component
-  // will handle positioning of elements, so it's not important to offset
-  // them correctly.
   return Children.map(children, (child) => {
-    const { props } = child as ReactElement;
-    const newProps = {
-      ...props,
-      style: [
-        props.style,
-        {
-          position: 'absolute',
-          left: 0,
-          top: 0,
-          right: 0,
-          bottom: 0,
-          width: undefined,
-          height: undefined,
-        },
-      ],
-      collapsable: false,
-    };
-    return React.cloneElement(child as ReactElement, newProps);
+    const element = child as React.ReactElement;
+    return (
+      // Add a wrapper to ensure layout is calculated correctly
+      <View style={StyleSheet.absoluteFill} collapsable={false}>
+        {React.cloneElement(element, {
+          ...element.props,
+          // Override styles so that each page will fill the parent.
+          style: [element.props.style, StyleSheet.absoluteFill],
+        })}
+      </View>
+    );
   });
 };


### PR DESCRIPTION
# Summary

#565 originally fixed this but #567 regressed it.

This should fix it again, more properly this time.

## Test Plan

- Open the "ScrollView inside PagerView Example" in an iOS simulator and rotate to landscape.
- Open the Keyboard Example and focus the text input, ensure the keyboard doesn't dismiss

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
