### PR TITLE
fix(android): assign an id to  on Android (#585)

### DIFF
--- a/android/src/main/java/com/reactnativepagerview/PagerViewViewManager.kt
+++ b/android/src/main/java/com/reactnativepagerview/PagerViewViewManager.kt
@@ -27,6 +27,7 @@ class PagerViewViewManager : ViewGroupManager<NestedScrollableHost>() {
 
   override fun createViewInstance(reactContext: ThemedReactContext): NestedScrollableHost {
     val host = NestedScrollableHost(reactContext)
+    host.id = View.generateViewId()
     host.layoutParams = ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
     host.isSaveEnabled = false
     val vp = ViewPager2(reactContext)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
Associate a non-taken Android ID to the `NestedScrollableHost`
`NestedScrollableHost` is created as a new class but never associated an ID. In one of our screen was creating a crash because the default id was already used. 
This was happening when re-recreating the view.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan
The changes just add a random Android ID not taken already. The test done has been:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?
Load screens with the page view.
Background and Foreground the app.
Enable Do not Keep Activities settings and do the previous steps.

### What are the steps to reproduce (after prerequisites)?
After the fix should not crash.

## Compatibility
This crash was only reproducible on Android

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
