### PR TITLE
fix(android): fix fabric build issue

### DIFF
--- a/android/src/turbo/PagerViewViewManager.kt
+++ b/android/src/turbo/PagerViewViewManager.kt
@@ -154,6 +154,16 @@ class PagerViewViewManager : ViewGroupManager<NestedScrollableHost>(), RNCViewPa
         }
     }
 
+    @ReactProp(name = "overdrag")
+    override fun setOverdrag(view: NestedScrollableHost?, value: Boolean) {
+        return
+    }
+
+    @ReactProp(name = "keyboardDismissMode")
+    override fun setKeyboardDismissMode(view: NestedScrollableHost?, value: String?) {
+        return
+    }
+
     fun goTo(root: NestedScrollableHost?, selectedPage: Int, scrollWithAnimation: Boolean) {
         if (root == null) {
             return


### PR DESCRIPTION
# Summary

This PR fixes building issue on **Android** which appeared after merging branch implementing Fabric on **Android** into Fabric migration branch.

When working on Fabric for **iOS**, two properties: _overdrag_ and _keyboardDismissMode_ (which are iOS only) were missing in spec file and were added into it, which caused build error on Android to appear.

## Test Plan
1. run ``yarn bootstrap-fabric``
2. inside ``fabricexample`` folder run ``yarn android``
## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |
