### PR TITLE
fix: on tab selection scroll when rtl enabled

### DIFF
--- a/ios/ReactNativePageView.m
+++ b/ios/ReactNativePageView.m
@@ -247,14 +247,20 @@
         return;
     }
     
-    BOOL isForward = (index > self.currentIndex && [self isLtrLayout]) || (index < self.currentIndex && ![self isLtrLayout]);
+    BOOL isRTL = ![self isLtrLayout];
+    
+    BOOL isForward = (index > self.currentIndex && !isRTL) || (index < self.currentIndex && isRTL);
+
+    
     UIPageViewControllerNavigationDirection direction = isForward ? UIPageViewControllerNavigationDirectionForward : UIPageViewControllerNavigationDirectionReverse;
     
     self.reactPageIndicatorView.numberOfPages = numberOfPages;
     self.reactPageIndicatorView.currentPage = index;
     long diff = labs(index - _currentIndex);
     
-    if (isForward && diff > 0) {
+    BOOL shouldGoForward = isRTL ? !isForward : isForward;
+    
+    if (shouldGoForward && diff > 0) {
         for (NSInteger i=_currentIndex; i<=index; i++) {
             if (i == _currentIndex) {
                 continue;
@@ -263,7 +269,7 @@
         }
     }
     
-    if (!isForward && diff > 0) {
+    if (!shouldGoForward && diff > 0) {
         for (NSInteger i=_currentIndex; i>=index; i--) {
             // Prevent removal of one or many pages at a time
             if (i == _currentIndex || i >= numberOfPages) {


### PR DESCRIPTION
# Summary
When RTL was enabled the forward direction is the other way around. This is why when isForward was true the for loop in line 264 (of updated code) was not running as when forward was true `_currentIndex` is greater than `index` preventing the for loop to happen. This is why when RTL is enabled I make a new variable to check whether it's enabled or not and if it is the isForward should be the opposite as when LTR is enabled.

the issues this pr close are : 
https://github.com/callstack/react-native-pager-view/issues/420


## Test Plan


https://user-images.githubusercontent.com/83782787/193692343-dd503612-305b-4bd9-914b-138a25464335.mov


https://user-images.githubusercontent.com/83782787/193692558-cfcd8f7f-c8c1-4e67-a69b-9bec33ce687d.mov



### What's required for testing (prerequisites)?
Run example project and test changes out

### What are the steps to reproduce (after prerequisites)?
Go to any pagerview example when running example dir app and in app.tsx `I18nManager.forceRTL(true)` for having RTL enable, then refresh app and try any example again. 

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
