### PR TITLE
fix: add missing SafeAreaView to fabric example

### DIFF
--- a/fabricexample/src/App.tsx
+++ b/fabricexample/src/App.tsx
@@ -7,7 +7,7 @@
  */
 
 import * as React from 'react';
-import { Image, StyleSheet, Text, View } from 'react-native';
+import { Image, SafeAreaView, StyleSheet, Text, View } from 'react-native';
 import ViewPager from 'react-native-pager-view';
 import { PAGES, createPage } from './utils';
 import { Button } from './component/Button';
@@ -105,7 +105,7 @@ export default class App extends React.Component<{}, State> {
   render() {
     const { page, pages, animationsAreEnabled, dotsVisible } = this.state;
     return (
-      <View style={styles.container}>
+      <SafeAreaView style={styles.container}>
         <ViewPager
           style={styles.viewPager}
           initialPage={0}
@@ -166,7 +166,7 @@ export default class App extends React.Component<{}, State> {
             progress={this.state.progress}
           />
         </View>
-      </View>
+      </SafeAreaView>
     );
   }
 }


### PR DESCRIPTION


# Summary

Small PR adding missing SafeAreaView to **Fabric** example, which was causing incorrect displaying on devices with notch/dynamic island. Now both examples (Paper and Fabric) have same behavior.

## Test Plan

1. run fabric example

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |
