### PR TITLE
fix(iOS): fix animation on onPageScroll event on Fabric

### DIFF
--- a/ios/Fabric/RNCPagerViewComponentView.mm
+++ b/ios/Fabric/RNCPagerViewComponentView.mm
@@ -10,6 +10,9 @@
 #import "RCTFabricComponentsPlugins.h"
 #import "React/RCTConversions.h"
 
+#import <React/RCTBridge+Private.h>
+#import "RCTOnPageScrollEvent.h"
+
 using namespace facebook::react;
 
 @interface RNCPagerViewComponentView () <RCTRNCViewPagerViewProtocol, UIPageViewControllerDataSource, UIPageViewControllerDelegate, UIScrollViewDelegate>
@@ -315,6 +318,15 @@ using namespace facebook::react;
     const auto strongEventEmitter = *std::dynamic_pointer_cast<const RNCViewPagerEventEmitter>(_eventEmitter);
     int eventPosition = (int) position;
     strongEventEmitter.onPageScroll(RNCViewPagerEventEmitter::OnPageScroll{.position =  static_cast<double>(eventPosition), .offset =  absoluteOffset});
+
+    //This is temporary workaround to allow animations based on onPageScroll event
+    //until Fabric implements proper NativeAnimationDriver
+    RCTBridge *bridge = [RCTBridge currentBridge];
+    
+    if (bridge) {
+        [bridge.eventDispatcher sendEvent:[[RCTOnPageScrollEvent alloc] initWithReactTag:[NSNumber numberWithInt:self.tag] position:@(position) offset:@(absoluteOffset)]];
+    }
+    
 }
 
 


### PR DESCRIPTION
# Summary

This PR fixes issue causing animations not to work on `onPageScroll` event on **Fabric** architecture on **iOS**.

This issue was reported in #618 

## Test Plan

1. open **Fabric** example app
2. select example with indicator e.g. _Headphones Carousel Example_
3. scroll to next page - animations should work as expected

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
