### PR TITLE
fix(iOS): fix pager view height issue on Fabric

### DIFF
--- a/ios/Fabric/RNCPagerViewComponentView.mm
+++ b/ios/Fabric/RNCPagerViewComponentView.mm
@@ -20,10 +20,6 @@ using namespace facebook::react;
 }
 
 - (void)initializeNativePageViewController {
-    if (_nativePageViewController) {
-        [_nativePageViewController.view removeFromSuperview];
-        _nativePageViewController = nil;
-    }
     const auto &viewProps = *std::static_pointer_cast<const RNCViewPagerProps>(_props);
     NSDictionary *options = @{ UIPageViewControllerOptionInterPageSpacingKey: @(viewProps.pageMargin) };
     UIPageViewControllerNavigationOrientation orientation = UIPageViewControllerNavigationOrientationHorizontal;
@@ -42,7 +38,7 @@ using namespace facebook::react;
     _nativePageViewController.dataSource = self;
     _nativePageViewController.delegate = self;
     _nativePageViewController.view.frame = self.frame;
-    [self addSubview:_nativePageViewController.view];
+    self.contentView = _nativePageViewController.view;
     
     for (UIView *subview in _nativePageViewController.view.subviews) {
         if([subview isKindOfClass:UIScrollView.class]){
@@ -67,12 +63,16 @@ using namespace facebook::react;
     return self;
 }
 
-
-
-- (void)layoutSubviews {
+-(void)layoutSubviews {
     [super layoutSubviews];
-    //Workaround to fix incorrect frame issue
-    [self goTo:_currentIndex animated:NO];
+    
+    [_nativePageViewController setViewControllers:@[[_nativeChildrenViewControllers objectAtIndex:_currentIndex]] direction: [self isLtrLayout] ? UIPageViewControllerNavigationDirectionForward : UIPageViewControllerNavigationDirectionReverse  animated:NO completion:nil];
+}
+
+- (void)willMoveToSuperview:(UIView *)newSuperview {
+    if (newSuperview != nil) {
+        [self initializeNativePageViewController];
+    }
 }
 
 
@@ -95,18 +95,15 @@ using namespace facebook::react;
     }
 }
 
-- (void)finalizeUpdates:(RNComponentViewUpdateMask)updateMask {
-    [super finalizeUpdates:updateMask];
-    
-    if (!_nativePageViewController) {
-        [self initializeNativePageViewController];
-    }
-}
 
--(void)prepareForRecycle{
+-(void)prepareForRecycle {
     [super prepareForRecycle];
     
-    [self initializeNativePageViewController];
+    _nativeChildrenViewControllers = [[NSMutableArray alloc] init];
+    [_nativePageViewController.view removeFromSuperview];
+    _nativePageViewController = nil;
+    
+    _currentIndex = -1;
 }
 
 - (void)shouldDismissKeyboard:(RNCViewPagerKeyboardDismissMode)dismissKeyboard {


### PR DESCRIPTION
# Summary

This PR fixes issue with incorrect _Pager View_ height causing blank space to appear.

This issue appeared only on **iOS** on **Fabric** architecture.

It was reported in #618 
## Test Plan

_Pager View_ should display correctly without blank space in every example on **Fabric**.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
