### PR TITLE
fix(iOS): fix setPage issue

### DIFF
--- a/ios/Fabric/RNCPagerViewComponentView.mm
+++ b/ios/Fabric/RNCPagerViewComponentView.mm
@@ -176,6 +176,8 @@ using namespace facebook::react;
 - (void)goTo:(NSInteger)index animated:(BOOL)animated {
     NSInteger numberOfPages = _nativeChildrenViewControllers.count;
     
+    _nativePageViewController.view.userInteractionEnabled = NO;
+    
     _destinationIndex = index;
     
     
@@ -210,6 +212,7 @@ using namespace facebook::react;
             int position = (int) index;
             strongEventEmitter.onPageSelected(RNCViewPagerEventEmitter::OnPageSelected{.position =  static_cast<double>(position)});
             strongSelf->_currentIndex = index;
+            strongSelf->_nativePageViewController.view.userInteractionEnabled = YES;
         }
     }];
 }

--- a/ios/ReactNativePageView.m
+++ b/ios/ReactNativePageView.m
@@ -178,6 +178,7 @@
         
         if (finished) {
             strongSelf.animating = NO;
+            strongSelf.reactPageViewController.view.userInteractionEnabled = YES;
         }
         
         if (strongSelf.eventDispatcher) {
@@ -224,6 +225,8 @@
 
 - (void)goTo:(NSInteger)index animated:(BOOL)animated {
     NSInteger numberOfPages = self.reactSubviews.count;
+    
+    _reactPageViewController.view.userInteractionEnabled = NO;
     
     _destinationIndex = index;
     


### PR DESCRIPTION
# Summary

This pull request fixes issue causing _setPage_ method to stop working. 
It does that by disabling user interactions while **Pager View** is animating to new page.

Fixes #649 
## Test Plan

As described in issue #649 

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist


- [X] I have tested this on a device and a simulator
