### PR TITLE
fix(ios): fix freeze after calling setpage

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -302,7 +302,7 @@ PODS:
   - React-jsinspector (0.70.5)
   - React-logger (0.70.5):
     - glog
-  - react-native-pager-view (6.1.0):
+  - react-native-pager-view (6.1.1):
     - React-Core
   - react-native-safe-area-context (3.4.1):
     - React-Core
@@ -617,7 +617,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 31564fa6912459921568e8b0e49024285a4d584b
   React-jsinspector: badd81696361249893a80477983e697aab3c1a34
   React-logger: fdda34dd285bdb0232e059b19d9606fa0ec3bb9c
-  react-native-pager-view: 7abf89f9834d9a4021b2fb6a5ef2abff570b46fb
+  react-native-pager-view: 3c66c4e2f3ab423643d07b2c7041f8ac48395f72
   react-native-safe-area-context: 9e40fb181dac02619414ba1294d6c2a807056ab9
   React-perflogger: e68d3795cf5d247a0379735cbac7309adf2fb931
   React-RCTActionSheet: 05452c3b281edb27850253db13ecd4c5a65bc247
@@ -640,6 +640,6 @@ SPEC CHECKSUMS:
   Yoga: eca980a5771bf114c41a754098cd85e6e0d90ed7
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 19416d7ab85e40fb19965457402ab8bdea762543
+PODFILE CHECKSUM: 7bb6ac2c486fd5b7d13ac3d8fc31d2174d38be56
 
 COCOAPODS: 1.11.3

--- a/fabricexample/ios/Podfile.lock
+++ b/fabricexample/ios/Podfile.lock
@@ -625,7 +625,7 @@ PODS:
   - React-jsinspector (0.70.5)
   - React-logger (0.70.5):
     - glog
-  - react-native-pager-view (6.1.0):
+  - react-native-pager-view (6.1.1):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -1013,7 +1013,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 31564fa6912459921568e8b0e49024285a4d584b
   React-jsinspector: badd81696361249893a80477983e697aab3c1a34
   React-logger: fdda34dd285bdb0232e059b19d9606fa0ec3bb9c
-  react-native-pager-view: dc682417cd0b172774331c3f664c23987b4c2eed
+  react-native-pager-view: 22ef94ca5a46cb18e4573ed3e179f4f84d477490
   react-native-safe-area-context: 2f75b317784a1a8e224562941e50ecbc932d2097
   React-perflogger: e68d3795cf5d247a0379735cbac7309adf2fb931
   React-RCTActionSheet: 05452c3b281edb27850253db13ecd4c5a65bc247
@@ -1037,6 +1037,6 @@ SPEC CHECKSUMS:
   Yoga: eca980a5771bf114c41a754098cd85e6e0d90ed7
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 5bfcc361dd0b2672ce6c798a07debb9513901bf6
+PODFILE CHECKSUM: 543e2b50cb719b002eca725e63b881ca716979e9
 
 COCOAPODS: 1.11.3

--- a/ios/Fabric/RNCPagerViewComponentView.mm
+++ b/ios/Fabric/RNCPagerViewComponentView.mm
@@ -173,10 +173,18 @@ using namespace facebook::react;
     [self goTo:index animated:NO];
 }
 
+- (void)disableSwipe {
+    self.nativePageViewController.view.userInteractionEnabled = NO;
+}
+
+- (void)enableSwipe {
+    self.nativePageViewController.view.userInteractionEnabled = YES;
+}
+
 - (void)goTo:(NSInteger)index animated:(BOOL)animated {
     NSInteger numberOfPages = _nativeChildrenViewControllers.count;
     
-    _nativePageViewController.view.userInteractionEnabled = NO;
+    [self disableSwipe];
     
     _destinationIndex = index;
     
@@ -188,9 +196,11 @@ using namespace facebook::react;
     BOOL isForward = (index > self.currentIndex && [self isLtrLayout]) || (index < self.currentIndex && ![self isLtrLayout]);
     UIPageViewControllerNavigationDirection direction = isForward ? UIPageViewControllerNavigationDirectionForward : UIPageViewControllerNavigationDirectionReverse;
     
+    long diff = labs(index - _currentIndex);
+    
     [self setPagerViewControllers:index
                         direction:direction
-                         animated:animated];
+                         animated:diff == 0 ? NO : animated];
     
 }
 
@@ -198,6 +208,7 @@ using namespace facebook::react;
                       direction:(UIPageViewControllerNavigationDirection)direction
                        animated:(BOOL)animated{
     if (_nativePageViewController == nil) {
+        [self enableSwipe];
         return;
     }
     
@@ -207,12 +218,12 @@ using namespace facebook::react;
                                          animated:animated
                                        completion:^(BOOL finished) {
         __strong RNCPagerViewComponentView *strongSelf = weakSelf;
+        [strongSelf enableSwipe];
         if (strongSelf->_eventEmitter != nullptr ) {
             const auto strongEventEmitter = *std::dynamic_pointer_cast<const RNCViewPagerEventEmitter>(strongSelf->_eventEmitter);
             int position = (int) index;
             strongEventEmitter.onPageSelected(RNCViewPagerEventEmitter::OnPageSelected{.position =  static_cast<double>(position)});
             strongSelf->_currentIndex = index;
-            strongSelf->_nativePageViewController.view.userInteractionEnabled = YES;
         }
     }];
 }

--- a/ios/ReactNativePageView.m
+++ b/ios/ReactNativePageView.m
@@ -153,11 +153,13 @@
                        animated:(BOOL)animated
                        shouldCallOnPageSelected:(BOOL)shouldCallOnPageSelected {
     if (self.reactPageViewController == nil) {
+        [self enableSwipe];
         return;
     }
 
     NSArray *currentVCs = self.reactPageViewController.viewControllers;
     if (currentVCs.count == 1 && [currentVCs.firstObject isEqual:controller]) {
+        [self enableSwipe];
         return;
     }
 
@@ -176,9 +178,10 @@
         strongSelf.currentIndex = index;
         strongSelf.currentView = controller.view;
         
+        [strongSelf enableSwipe];
+        
         if (finished) {
             strongSelf.animating = NO;
-            strongSelf.reactPageViewController.view.userInteractionEnabled = YES;
         }
         
         if (strongSelf.eventDispatcher) {
@@ -223,10 +226,18 @@
     }
 }
 
+- (void)disableSwipe {
+    self.reactPageViewController.view.userInteractionEnabled = NO;
+}
+
+- (void)enableSwipe {
+    self.reactPageViewController.view.userInteractionEnabled = YES;
+}
+
 - (void)goTo:(NSInteger)index animated:(BOOL)animated {
     NSInteger numberOfPages = self.reactSubviews.count;
     
-    _reactPageViewController.view.userInteractionEnabled = NO;
+    [self disableSwipe];
     
     _destinationIndex = index;
     


### PR DESCRIPTION
# Summary

This pull request fixes issue causing **Pager View** to freeze after calling _setPage_ method.

It was caused by not re-enabling user interactions in certain situations. 

User interactions are being disabled after calling the _setPage_ method until the transition to the next page is complete, as it caused unexpected **Pager View** behavior.

Also small refactor has been introduced to improve code readability.

## Test Plan

**Pager View** should be interactive after calling _setPage_ method (on both **Fabric** and **Paper** architectures)

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
