### PR TITLE
feat(iOS): change Fabric implementation to UIScrollView

### DIFF
--- a/common/cpp/react/renderer/components/RNCViewPager/RNCViewPagerComponentDescriptor.h
+++ b/common/cpp/react/renderer/components/RNCViewPager/RNCViewPagerComponentDescriptor.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "RNCViewPagerShadowNode.h"
+#include <react/renderer/core/ConcreteComponentDescriptor.h>
+
+namespace facebook {
+namespace react {
+
+using RNCViewPagerComponentDescriptor = ConcreteComponentDescriptor<RNCViewPagerShadowNode>;
+
+}
+}

--- a/common/cpp/react/renderer/components/RNCViewPager/RNCViewPagerShadowNode.cpp
+++ b/common/cpp/react/renderer/components/RNCViewPager/RNCViewPagerShadowNode.cpp
@@ -1,0 +1,35 @@
+#include "RNCViewPagerShadowNode.h"
+
+#include <react/debug/react_native_assert.h>
+#include <react/renderer/core/LayoutMetrics.h>
+
+namespace facebook {
+namespace react {
+
+const char RNCViewPagerComponentName[] = "RNCViewPager";
+
+void RNCViewPagerShadowNode::updateStateIfNeeded() {
+    ensureUnsealed();
+    
+    auto contentBoundingRect = Rect{};
+    for (const auto &childNode : getLayoutableChildNodes()) {
+        contentBoundingRect.unionInPlace(childNode->getLayoutMetrics().frame);
+    }
+    
+    auto state = getStateData();
+    
+    if (state.contentBoundingRect != contentBoundingRect) {
+        state.contentBoundingRect = contentBoundingRect;
+        setStateData(std::move(state));
+    }
+}
+
+#pragma mark - LayoutableShadowNode
+
+void RNCViewPagerShadowNode::layout(LayoutContext layoutContext) {
+    ConcreteViewShadowNode::layout(layoutContext);
+    updateStateIfNeeded();
+}
+
+}
+}

--- a/common/cpp/react/renderer/components/RNCViewPager/RNCViewPagerShadowNode.h
+++ b/common/cpp/react/renderer/components/RNCViewPager/RNCViewPagerShadowNode.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <react/renderer/components/RNCViewPager/EventEmitters.h>
+#include <react/renderer/components/RNCViewPager/Props.h>
+#include <react/renderer/components/RNCViewPager/RNCViewPagerState.h>
+#include <react/renderer/components/view/ConcreteViewShadowNode.h>
+#include <react/renderer/core/LayoutContext.h>
+
+namespace facebook {
+namespace react {
+
+extern const char RNCViewPagerComponentName[];
+
+class RNCViewPagerShadowNode final : public ConcreteViewShadowNode<
+                                                RNCViewPagerComponentName,
+                                                RNCViewPagerProps,
+                                                RNCViewPagerEventEmitter,
+                                                RNCViewPagerState> {
+public:
+    using ConcreteViewShadowNode::ConcreteViewShadowNode;
+    
+#pragma mark - LayoutableShadowNode
+    
+    void layout(LayoutContext layoutContext) override;
+    
+private:
+    void updateStateIfNeeded();
+};
+
+}
+}

--- a/common/cpp/react/renderer/components/RNCViewPager/RNCViewPagerState.cpp
+++ b/common/cpp/react/renderer/components/RNCViewPager/RNCViewPagerState.cpp
@@ -1,0 +1,11 @@
+#include "RNCViewPagerState.h"
+
+namespace facebook {
+namespace react {
+
+Size RNCViewPagerState::getContentSize() const {
+    return contentBoundingRect.size;
+}
+
+}
+}

--- a/common/cpp/react/renderer/components/RNCViewPager/RNCViewPagerState.h
+++ b/common/cpp/react/renderer/components/RNCViewPager/RNCViewPagerState.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <react/renderer/graphics/Geometry.h>
+
+namespace facebook {
+namespace react {
+
+class RNCViewPagerState final {
+public:
+    Point contentOffset;
+    Rect contentBoundingRect;
+    
+    Size getContentSize() const;
+    
+};
+
+}
+}

--- a/example/src/NestPagerView.tsx
+++ b/example/src/NestPagerView.tsx
@@ -20,12 +20,12 @@ export function NestPagerView() {
       >
         <View
           key="1"
-          style={{ backgroundColor: BGCOLOR[0] }}
+          style={[styles.page, { backgroundColor: BGCOLOR[0] }]}
           collapsable={false}
         >
           <LikeCount />
         </View>
-        <View key="2" collapsable={false}>
+        <View style={styles.page} key="2" collapsable={false}>
           <Text style={styles.title}>
             There has two Nest PagerView with horizontal and vertical.
           </Text>
@@ -39,7 +39,7 @@ export function NestPagerView() {
           >
             <View
               key="1"
-              style={{ backgroundColor: BGCOLOR[1] }}
+              style={[styles.page, { backgroundColor: BGCOLOR[1] }]}
               collapsable={false}
             >
               <LikeCount />
@@ -47,7 +47,7 @@ export function NestPagerView() {
             </View>
             <View
               key="2"
-              style={{ backgroundColor: BGCOLOR[2] }}
+              style={[styles.page, { backgroundColor: BGCOLOR[2] }]}
               collapsable={false}
             >
               <LikeCount />
@@ -64,7 +64,7 @@ export function NestPagerView() {
           >
             <View
               key="1"
-              style={{ backgroundColor: BGCOLOR[3] }}
+              style={[styles.page, { backgroundColor: BGCOLOR[3] }]}
               collapsable={false}
             >
               <LikeCount />
@@ -72,7 +72,7 @@ export function NestPagerView() {
             </View>
             <View
               key="2"
-              style={{ backgroundColor: BGCOLOR[4] }}
+              style={[styles.page, { backgroundColor: BGCOLOR[4] }]}
               collapsable={false}
             >
               <LikeCount />
@@ -82,7 +82,7 @@ export function NestPagerView() {
         </View>
         <View
           key="3"
-          style={{ backgroundColor: BGCOLOR[3] }}
+          style={[styles.page, { backgroundColor: BGCOLOR[3] }]}
           collapsable={false}
         >
           <LikeCount />
@@ -103,6 +103,9 @@ const styles = StyleSheet.create({
     padding: 20,
   },
   PagerView: {
+    flex: 1,
+  },
+  page: {
     flex: 1,
   },
   title: { fontSize: 22, paddingVertical: 10 },

--- a/example/src/PaginationDotsExample.tsx
+++ b/example/src/PaginationDotsExample.tsx
@@ -166,6 +166,7 @@ const styles = StyleSheet.create({
   },
   progressContainer: { flex: 0.1, backgroundColor: '#63a4ff' },
   center: {
+    flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
     alignContent: 'center',

--- a/example/src/utils.ts
+++ b/example/src/utils.ts
@@ -23,6 +23,7 @@ export const createPage = (key: number): CreatePage => {
   return {
     key: key,
     style: {
+      flex: 1,
       backgroundColor: BGCOLOR[key % BGCOLOR.length],
       alignItems: 'center',
       padding: 20,

--- a/fabricexample/ios/Podfile.lock
+++ b/fabricexample/ios/Podfile.lock
@@ -625,7 +625,16 @@ PODS:
   - React-jsinspector (0.70.5)
   - React-logger (0.70.5):
     - glog
-  - react-native-pager-view (6.1.1):
+  - react-native-pager-view (6.1.2):
+    - RCT-Folly
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Codegen
+    - React-Core
+    - react-native-pager-view/common (= 6.1.2)
+    - React-RCTFabric
+    - ReactCommon/turbomodule/core
+  - react-native-pager-view/common (6.1.2):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -1013,7 +1022,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 31564fa6912459921568e8b0e49024285a4d584b
   React-jsinspector: badd81696361249893a80477983e697aab3c1a34
   React-logger: fdda34dd285bdb0232e059b19d9606fa0ec3bb9c
-  react-native-pager-view: 22ef94ca5a46cb18e4573ed3e179f4f84d477490
+  react-native-pager-view: 991c947924d48f1232a98ba6e6d3466eaf51034d
   react-native-safe-area-context: 2f75b317784a1a8e224562941e50ecbc932d2097
   React-perflogger: e68d3795cf5d247a0379735cbac7309adf2fb931
   React-RCTActionSheet: 05452c3b281edb27850253db13ecd4c5a65bc247

--- a/fabricexample/src/NestPagerView.tsx
+++ b/fabricexample/src/NestPagerView.tsx
@@ -20,12 +20,12 @@ export function NestPagerView() {
       >
         <View
           key="1"
-          style={{ backgroundColor: BGCOLOR[0] }}
+          style={[styles.page, { backgroundColor: BGCOLOR[0] }]}
           collapsable={false}
         >
           <LikeCount />
         </View>
-        <View key="2" collapsable={false}>
+        <View style={styles.page} key="2" collapsable={false}>
           <Text style={styles.title}>
             There has two Nest PagerView with horizontal and vertical.
           </Text>
@@ -39,7 +39,7 @@ export function NestPagerView() {
           >
             <View
               key="1"
-              style={{ backgroundColor: BGCOLOR[1] }}
+              style={[styles.page, { backgroundColor: BGCOLOR[1] }]}
               collapsable={false}
             >
               <LikeCount />
@@ -47,7 +47,7 @@ export function NestPagerView() {
             </View>
             <View
               key="2"
-              style={{ backgroundColor: BGCOLOR[2] }}
+              style={[styles.page, { backgroundColor: BGCOLOR[2] }]}
               collapsable={false}
             >
               <LikeCount />
@@ -64,7 +64,7 @@ export function NestPagerView() {
           >
             <View
               key="1"
-              style={{ backgroundColor: BGCOLOR[3] }}
+              style={[styles.page, { backgroundColor: BGCOLOR[3] }]}
               collapsable={false}
             >
               <LikeCount />
@@ -72,7 +72,7 @@ export function NestPagerView() {
             </View>
             <View
               key="2"
-              style={{ backgroundColor: BGCOLOR[4] }}
+              style={[styles.page, { backgroundColor: BGCOLOR[4] }]}
               collapsable={false}
             >
               <LikeCount />
@@ -82,7 +82,7 @@ export function NestPagerView() {
         </View>
         <View
           key="3"
-          style={{ backgroundColor: BGCOLOR[3] }}
+          style={[styles.page, { backgroundColor: BGCOLOR[3] }]}
           collapsable={false}
         >
           <LikeCount />
@@ -103,6 +103,9 @@ const styles = StyleSheet.create({
     padding: 20,
   },
   PagerView: {
+    flex: 1,
+  },
+  page: {
     flex: 1,
   },
   title: { fontSize: 22, paddingVertical: 10 },

--- a/fabricexample/src/PaginationDotsExample.tsx
+++ b/fabricexample/src/PaginationDotsExample.tsx
@@ -166,6 +166,7 @@ const styles = StyleSheet.create({
   },
   progressContainer: { flex: 0.1, backgroundColor: '#63a4ff' },
   center: {
+    flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
     alignContent: 'center',

--- a/fabricexample/src/utils.ts
+++ b/fabricexample/src/utils.ts
@@ -23,6 +23,7 @@ export const createPage = (key: number): CreatePage => {
   return {
     key: key,
     style: {
+      flex: 1,
       backgroundColor: BGCOLOR[key % BGCOLOR.length],
       alignItems: 'center',
       padding: 20,

--- a/ios/Fabric/RNCPagerViewComponentView.h
+++ b/ios/Fabric/RNCPagerViewComponentView.h
@@ -7,14 +7,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface RNCPagerViewComponentView : RCTViewComponentView <UIPageViewControllerDataSource, UIPageViewControllerDelegate, UIScrollViewDelegate>
+@interface RNCPagerViewComponentView : RCTViewComponentView <UIScrollViewDelegate>
 
-@property(strong, nonatomic, readonly) UIPageViewController *nativePageViewController;
-@property(nonatomic, strong) NSMutableArray<UIViewController *> *nativeChildrenViewControllers;
-@property(nonatomic) NSInteger initialPage;
-@property(nonatomic) NSInteger currentIndex;
-@property(nonatomic) NSInteger destinationIndex;
-@property(nonatomic) NSString* layoutDirection;
 @property(nonatomic) BOOL overdrag;
 
 - (void)setPage:(NSInteger)number;

--- a/ios/Fabric/RNCPagerViewComponentView.mm
+++ b/ios/Fabric/RNCPagerViewComponentView.mm
@@ -2,7 +2,7 @@
 
 #import <Foundation/Foundation.h>
 #import "RNCPagerViewComponentView.h"
-#import <react/renderer/components/RNCViewPager/ComponentDescriptors.h>
+#import <RNCViewPager/RNCViewPagerComponentDescriptor.h>
 #import <react/renderer/components/RNCViewPager/EventEmitters.h>
 #import <react/renderer/components/RNCViewPager/Props.h>
 #import <react/renderer/components/RNCViewPager/RCTComponentViewHelpers.h>
@@ -15,42 +15,15 @@
 
 using namespace facebook::react;
 
-@interface RNCPagerViewComponentView () <RCTRNCViewPagerViewProtocol, UIPageViewControllerDataSource, UIPageViewControllerDelegate, UIScrollViewDelegate>
+@interface RNCPagerViewComponentView () <RCTRNCViewPagerViewProtocol, UIScrollViewDelegate>
 @end
 
 @implementation RNCPagerViewComponentView {
-    LayoutMetrics _layoutMetrics;
-    UIScrollView *scrollView;
-}
-
-- (void)initializeNativePageViewController {
-    const auto &viewProps = *std::static_pointer_cast<const RNCViewPagerProps>(_props);
-    NSDictionary *options = @{ UIPageViewControllerOptionInterPageSpacingKey: @(viewProps.pageMargin) };
-    UIPageViewControllerNavigationOrientation orientation = UIPageViewControllerNavigationOrientationHorizontal;
-    switch (viewProps.orientation) {
-        case RNCViewPagerOrientation::Horizontal:
-            orientation = UIPageViewControllerNavigationOrientationHorizontal;
-            break;
-        case RNCViewPagerOrientation::Vertical:
-            orientation = UIPageViewControllerNavigationOrientationVertical;
-            break;
-    }
-    _nativePageViewController = [[UIPageViewController alloc]
-                                 initWithTransitionStyle: UIPageViewControllerTransitionStyleScroll
-                                 navigationOrientation:orientation
-                                 options:options];
-    _nativePageViewController.dataSource = self;
-    _nativePageViewController.delegate = self;
-    _nativePageViewController.view.frame = self.frame;
-    self.contentView = _nativePageViewController.view;
+    RNCViewPagerShadowNode::ConcreteState::Shared _state;
+    UIScrollView *_scrollView;
+    UIView *_containerView;
     
-    for (UIView *subview in _nativePageViewController.view.subviews) {
-        if([subview isKindOfClass:UIScrollView.class]){
-            ((UIScrollView *)subview).delegate = self;
-            ((UIScrollView *)subview).delaysContentTouches = NO;
-            scrollView = (UIScrollView *)subview;
-        }
-    }
+    CGSize _contentSize;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -58,197 +31,88 @@ using namespace facebook::react;
     if (self = [super initWithFrame:frame]) {
         static const auto defaultProps = std::make_shared<const RNCViewPagerProps>();
         _props = defaultProps;
-        _nativeChildrenViewControllers = [[NSMutableArray alloc] init];
-        _currentIndex = -1;
-        _destinationIndex = -1;
-        _layoutDirection = @"ltr";
-        _overdrag = NO;
+        
+        _scrollView = [[UIScrollView alloc] initWithFrame:self.bounds];
+        
+        _scrollView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+        _scrollView.delaysContentTouches = NO;
+        _scrollView.delegate = self;
+        _scrollView.pagingEnabled = YES;
+        _scrollView.showsHorizontalScrollIndicator = NO;
+        _scrollView.showsVerticalScrollIndicator = NO;
+        
+        [self addSubview:_scrollView];
+        
+        _containerView = [[UIView alloc] initWithFrame:CGRectZero];
+        
+        [_scrollView addSubview:_containerView];
     }
     
     return self;
 }
 
-- (void)willMoveToSuperview:(UIView *)newSuperview {
-    if (newSuperview != nil) {
-        [self initializeNativePageViewController];
-        [self goTo:_currentIndex animated:NO];
-    }
-}
-
 
 #pragma mark - React API
-
-- (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index {
-    UIViewController *wrapper = [[UIViewController alloc] initWithView:childComponentView];
-    [_nativeChildrenViewControllers insertObject:wrapper atIndex:index];
-}
-
-- (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index {
-    [[_nativeChildrenViewControllers objectAtIndex:index].view removeFromSuperview];
-    [_nativeChildrenViewControllers objectAtIndex:index].view = nil;
-    [_nativeChildrenViewControllers removeObjectAtIndex:index];
- 
-    NSInteger maxPage = _nativeChildrenViewControllers.count - 1;
-    
-    if (self.currentIndex >= maxPage) {
-        [self goTo:maxPage animated:NO];
-    }
-}
-
-
--(void)updateLayoutMetrics:(const facebook::react::LayoutMetrics &)layoutMetrics oldLayoutMetrics:(const facebook::react::LayoutMetrics &)oldLayoutMetrics {
-    [super updateLayoutMetrics:layoutMetrics oldLayoutMetrics:_layoutMetrics];
-    self.contentView.frame = RCTCGRectFromRect(_layoutMetrics.getContentFrame());
-    _layoutMetrics = layoutMetrics;
-}
-
-
--(void)prepareForRecycle {
-    [super prepareForRecycle];
-    
-    _nativeChildrenViewControllers = [[NSMutableArray alloc] init];
-    [_nativePageViewController.view removeFromSuperview];
-    _nativePageViewController = nil;
-    
-    _currentIndex = -1;
-}
-
-- (void)shouldDismissKeyboard:(RNCViewPagerKeyboardDismissMode)dismissKeyboard {
-    UIScrollViewKeyboardDismissMode dismissKeyboardMode = UIScrollViewKeyboardDismissModeNone;
-    switch (dismissKeyboard) {
-        case RNCViewPagerKeyboardDismissMode::None:
-            dismissKeyboardMode = UIScrollViewKeyboardDismissModeNone;
-            break;
-        case RNCViewPagerKeyboardDismissMode::OnDrag:
-            dismissKeyboardMode = UIScrollViewKeyboardDismissModeOnDrag;
-            break;
-    }
-    scrollView.keyboardDismissMode = dismissKeyboardMode;
-}
-
 
 - (void)updateProps:(const facebook::react::Props::Shared &)props oldProps:(const facebook::react::Props::Shared &)oldProps{
     const auto &oldScreenProps = *std::static_pointer_cast<const RNCViewPagerProps>(_props);
     const auto &newScreenProps = *std::static_pointer_cast<const RNCViewPagerProps>(props);
     
-    // change index only once
-    if (_currentIndex == -1) {
-        _currentIndex = newScreenProps.initialPage;
-        [self shouldDismissKeyboard: newScreenProps.keyboardDismissMode];
+    if (_scrollView.bounces != newScreenProps.overdrag) {
+        [_scrollView setBounces: newScreenProps.overdrag];
     }
     
-    const auto newLayoutDirectionStr = RCTNSStringFromString(toString(newScreenProps.layoutDirection));
-    
-    
-    if (self.layoutDirection != newLayoutDirectionStr) {
-        self.layoutDirection = newLayoutDirectionStr;
+    if (_scrollView.scrollEnabled != newScreenProps.scrollEnabled) {
+        [_scrollView setScrollEnabled:newScreenProps.scrollEnabled];
     }
     
-    if (oldScreenProps.keyboardDismissMode != newScreenProps.keyboardDismissMode) {
-        [self shouldDismissKeyboard: newScreenProps.keyboardDismissMode];
-    }
-    
-    if (newScreenProps.scrollEnabled != scrollView.scrollEnabled) {
-        scrollView.scrollEnabled = newScreenProps.scrollEnabled;
-    }
-    
-    if (newScreenProps.overdrag != _overdrag) {
-        _overdrag = newScreenProps.overdrag;
-    }
     
     [super updateProps:props oldProps:oldProps];
+}
+
+- (void)updateState:(State::Shared const &)state oldState:(State::Shared const &)oldState
+{
+    assert(std::dynamic_pointer_cast<RNCViewPagerShadowNode::ConcreteState const>(state));
+    _state = std::static_pointer_cast<RNCViewPagerShadowNode::ConcreteState const>(state);
+    auto &data = _state->getData();
+    
+    auto contentOffset = RCTCGPointFromPoint(data.contentOffset);
+    if (!oldState && !CGPointEqualToPoint(contentOffset, CGPointZero)) {
+        _scrollView.contentOffset = contentOffset;
+    }
+    
+    CGSize contentSize = RCTCGSizeFromSize(data.getContentSize());
+    
+    if (CGSizeEqualToSize(_contentSize, contentSize)) {
+        return;
+    }
+    
+    _contentSize = contentSize;
+    _containerView.frame = CGRect{RCTCGPointFromPoint(data.contentBoundingRect.origin), contentSize};
+    
+    _scrollView.contentSize = contentSize;
+ 
+}
+
+- (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
+{
+    [_containerView insertSubview:childComponentView atIndex:index];
+}
+
+- (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
+{
+    [childComponentView removeFromSuperview];
 }
 
 - (void)handleCommand:(const NSString *)commandName args:(const NSArray *)args {
     RCTRNCViewPagerHandleCommand(self, commandName, args);
 }
 
-#pragma mark - Internal methods
-
-- (void)setPage:(NSInteger)index {
-    [self goTo:index animated:YES];
-}
-
-- (void)setPageWithoutAnimation:(NSInteger)index {
-    [self goTo:index animated:NO];
-}
-
-- (void)disableSwipe {
-    self.nativePageViewController.view.userInteractionEnabled = NO;
-}
-
-- (void)enableSwipe {
-    self.nativePageViewController.view.userInteractionEnabled = YES;
-}
-
-- (void)goTo:(NSInteger)index animated:(BOOL)animated {
-    NSInteger numberOfPages = _nativeChildrenViewControllers.count;
-    
-    [self disableSwipe];
-    
-    _destinationIndex = index;
-    
-    
-    if (numberOfPages == 0 || index < 0 || index > numberOfPages - 1) {
-        return;
-    }
-    
-    BOOL isForward = (index > self.currentIndex && [self isLtrLayout]) || (index < self.currentIndex && ![self isLtrLayout]);
-    UIPageViewControllerNavigationDirection direction = isForward ? UIPageViewControllerNavigationDirectionForward : UIPageViewControllerNavigationDirectionReverse;
-    
-    long diff = labs(index - _currentIndex);
-    
-    [self setPagerViewControllers:index
-                        direction:direction
-                         animated:diff == 0 ? NO : animated];
-    
-}
-
-- (void)setPagerViewControllers:(NSInteger)index
-                      direction:(UIPageViewControllerNavigationDirection)direction
-                       animated:(BOOL)animated{
-    if (_nativePageViewController == nil) {
-        [self enableSwipe];
-        return;
-    }
-    
-    __weak RNCPagerViewComponentView *weakSelf = self;
-    [_nativePageViewController setViewControllers:@[[_nativeChildrenViewControllers objectAtIndex:index]]
-                                        direction:direction
-                                         animated:animated
-                                       completion:^(BOOL finished) {
-        __strong RNCPagerViewComponentView *strongSelf = weakSelf;
-        [strongSelf enableSwipe];
-        if (strongSelf->_eventEmitter != nullptr ) {
-            const auto strongEventEmitter = *std::dynamic_pointer_cast<const RNCViewPagerEventEmitter>(strongSelf->_eventEmitter);
-            int position = (int) index;
-            strongEventEmitter.onPageSelected(RNCViewPagerEventEmitter::OnPageSelected{.position =  static_cast<double>(position)});
-            strongSelf->_currentIndex = index;
-        }
-    }];
-}
-
-
-- (UIViewController *)nextControllerForController:(UIViewController *)controller
-                                      inDirection:(UIPageViewControllerNavigationDirection)direction {
-    NSUInteger numberOfPages = _nativeChildrenViewControllers.count;
-    NSInteger index = [_nativeChildrenViewControllers indexOfObject:controller];
-    
-    if (index == NSNotFound) {
-        return nil;
-    }
-    
-    direction == UIPageViewControllerNavigationDirectionForward ? index++ : index--;
-    
-    if (index < 0 || (index > (numberOfPages - 1))) {
-        return nil;
-    }
-    
-    return [_nativeChildrenViewControllers objectAtIndex:index];
-}
-
-- (UIViewController *)currentlyDisplayed {
-    return _nativePageViewController.viewControllers.firstObject;
+- (void)prepareForRecycle
+{
+    _state.reset();
+    [_scrollView setContentOffset:CGPointZero];
+    [super prepareForRecycle];
 }
 
 #pragma mark - UIScrollViewDelegate
@@ -260,130 +124,71 @@ using namespace facebook::react;
 
 - (void)scrollViewWillEndDragging:(UIScrollView *)scrollView withVelocity:(CGPoint)velocity targetContentOffset:(inout CGPoint *)targetContentOffset {
     
-    if (!_overdrag) {
-        NSInteger maxIndex = _nativeChildrenViewControllers.count - 1;
-        BOOL isFirstPage = [self isLtrLayout] ? _currentIndex == 0 : _currentIndex == maxIndex;
-        BOOL isLastPage = [self isLtrLayout] ? _currentIndex == maxIndex : _currentIndex == 0;
-        CGFloat contentOffset = [self isHorizontal] ? scrollView.contentOffset.x : scrollView.contentOffset.y;
-        CGFloat topBound = [self isHorizontal] ? scrollView.bounds.size.width : scrollView.bounds.size.height;
-        
-        if ((isFirstPage && contentOffset <= topBound) || (isLastPage && contentOffset >= topBound)) {
-            CGPoint croppedOffset = [self isHorizontal] ? CGPointMake(topBound, 0) : CGPointMake(0, topBound);
-            *targetContentOffset = croppedOffset;
-        }
-    }
-    
     const auto strongEventEmitter = *std::dynamic_pointer_cast<const RNCViewPagerEventEmitter>(_eventEmitter);
     strongEventEmitter.onPageScrollStateChanged(RNCViewPagerEventEmitter::OnPageScrollStateChanged{.pageScrollState =  RNCViewPagerEventEmitter::OnPageScrollStateChangedPageScrollState::Settling });
 }
 
 - (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView {
+    int position = [self getCurrentPage];
+    
     const auto strongEventEmitter = *std::dynamic_pointer_cast<const RNCViewPagerEventEmitter>(_eventEmitter);
+    
     strongEventEmitter.onPageScrollStateChanged(RNCViewPagerEventEmitter::OnPageScrollStateChanged{.pageScrollState =  RNCViewPagerEventEmitter::OnPageScrollStateChangedPageScrollState::Idle });
+    
+    strongEventEmitter.onPageSelected(RNCViewPagerEventEmitter::OnPageSelected{.position =  static_cast<double>(position)});
 }
 
-- (BOOL)isHorizontal {
-    return _nativePageViewController.navigationOrientation == UIPageViewControllerNavigationOrientationHorizontal;
-}
-
-- (BOOL)isLtrLayout {
-    return [_layoutDirection isEqualToString: @"ltr"];
-}
-
-- (void)scrollViewDidScroll:(UIScrollView *)scrollView {
-    CGPoint point = scrollView.contentOffset;
-    
-    float offset = 0;
-    
-    if (self.isHorizontal) {
-        if (scrollView.frame.size.width != 0) {
-            offset = (point.x - scrollView.frame.size.width)/scrollView.frame.size.width;
-        }
-    } else {
-        if (scrollView.frame.size.height != 0) {
-            offset = (point.y - scrollView.frame.size.height)/scrollView.frame.size.height;
-        }
-    }
-    
-    float absoluteOffset = fabs(offset);
-    
-    NSInteger position = self.currentIndex;
-    
-    BOOL isAnimatingBackwards = offset<0;
-    
-    if (scrollView.isDragging) {
-        _destinationIndex = isAnimatingBackwards ? _currentIndex - 1 : _currentIndex + 1;
-    }
-    
-    if (isAnimatingBackwards) {
-        position =  _destinationIndex;
-        absoluteOffset =  fmax(0, 1 - absoluteOffset);
-    }
-    
-    if (!_overdrag) {
-        NSInteger maxIndex = _nativeChildrenViewControllers.count - 1;
-        NSInteger firstPageIndex = [self isLtrLayout] ?  0 :  maxIndex;
-        NSInteger lastPageIndex = [self isLtrLayout] ?  maxIndex :  0;
-        BOOL isFirstPage = _currentIndex == firstPageIndex;
-        BOOL isLastPage = _currentIndex == lastPageIndex;
-        CGFloat contentOffset =[self isHorizontal] ? scrollView.contentOffset.x : scrollView.contentOffset.y;
-        CGFloat topBound = [self isHorizontal] ? scrollView.bounds.size.width : scrollView.bounds.size.height;
-        
-        if ((isFirstPage && contentOffset <= topBound) || (isLastPage && contentOffset >= topBound)) {
-            CGPoint croppedOffset = [self isHorizontal] ? CGPointMake(topBound, 0) : CGPointMake(0, topBound);
-            scrollView.contentOffset = croppedOffset;
-            absoluteOffset=0;
-            position = isLastPage ? lastPageIndex : firstPageIndex;
-        }
-    }
-    
-    float interpolatedOffset = absoluteOffset * labs(_destinationIndex - _currentIndex);
+//Handles sending onPageSelected event on setPage method completion
+-(void)scrollViewDidEndScrollingAnimation:(UIScrollView *)scrollView {
+    int position = [self getCurrentPage];
     
     const auto strongEventEmitter = *std::dynamic_pointer_cast<const RNCViewPagerEventEmitter>(_eventEmitter);
-    int eventPosition = (int) position;
-    strongEventEmitter.onPageScroll(RNCViewPagerEventEmitter::OnPageScroll{.position =  static_cast<double>(eventPosition), .offset = interpolatedOffset});
+    
+    strongEventEmitter.onPageSelected(RNCViewPagerEventEmitter::OnPageSelected{.position =  static_cast<double>(position)});
+}
 
+-(void)scrollViewDidScroll:(UIScrollView *)scrollView {
+    int position = [self getCurrentPage];
+    
+    double offset = (scrollView.contentOffset.x - (scrollView.frame.size.width * position))/scrollView.frame.size.width;
+    
+    const auto strongEventEmitter = *std::dynamic_pointer_cast<const RNCViewPagerEventEmitter>(_eventEmitter);
+    
+    strongEventEmitter.onPageScroll(RNCViewPagerEventEmitter::OnPageScroll{.position =  static_cast<double>(position), .offset = offset});
+    
     //This is temporary workaround to allow animations based on onPageScroll event
     //until Fabric implements proper NativeAnimationDriver
     RCTBridge *bridge = [RCTBridge currentBridge];
     
     if (bridge) {
-        [bridge.eventDispatcher sendEvent:[[RCTOnPageScrollEvent alloc] initWithReactTag:[NSNumber numberWithInt:self.tag] position:@(position) offset:@(interpolatedOffset)]];
-    }
-    
-}
-
-
-#pragma mark - UIPageViewControllerDelegate
-
-- (void)pageViewController:(UIPageViewController *)pageViewController
-        didFinishAnimating:(BOOL)finished
-   previousViewControllers:(nonnull NSArray<UIViewController *> *)previousViewControllers
-       transitionCompleted:(BOOL)completed {
-    if (completed) {
-        UIViewController* currentVC = [self currentlyDisplayed];
-        NSUInteger currentIndex = [_nativeChildrenViewControllers indexOfObject:currentVC];
-        _currentIndex = currentIndex;
-        int position = (int) currentIndex;
-        const auto strongEventEmitter = *std::dynamic_pointer_cast<const RNCViewPagerEventEmitter>(_eventEmitter);
-        strongEventEmitter.onPageSelected(RNCViewPagerEventEmitter::OnPageSelected{.position =  static_cast<double>(position)});
-        strongEventEmitter.onPageScroll(RNCViewPagerEventEmitter::OnPageScroll{.position =  static_cast<double>(position), .offset =  0.0});
+        [bridge.eventDispatcher sendEvent:[[RCTOnPageScrollEvent alloc] initWithReactTag:[NSNumber numberWithInt:self.tag] position:@(position) offset:@(offset)]];
     }
 }
 
-#pragma mark - UIPageViewControllerDataSource
+#pragma mark - Internal methods
 
-- (UIViewController *)pageViewController:(UIPageViewController *)pageViewController
-       viewControllerAfterViewController:(UIViewController *)viewController {
-    
-    UIPageViewControllerNavigationDirection direction = [self isLtrLayout] ? UIPageViewControllerNavigationDirectionForward : UIPageViewControllerNavigationDirectionReverse;
-    return [self nextControllerForController:viewController inDirection:direction];
+-(bool)isHorizontal {
+    return _scrollView.contentSize.width > _scrollView.contentSize.height;
 }
 
-- (UIViewController *)pageViewController:(UIPageViewController *)pageViewController
-      viewControllerBeforeViewController:(UIViewController *)viewController {
-    UIPageViewControllerNavigationDirection direction = [self isLtrLayout] ? UIPageViewControllerNavigationDirectionReverse : UIPageViewControllerNavigationDirectionForward;
-    return [self nextControllerForController:viewController inDirection:direction];
+-(int)getCurrentPage {
+    return [self isHorizontal] ? _scrollView.contentOffset.x / _scrollView.frame.size.width : _scrollView.contentOffset.y / _scrollView.frame.size.height;
+}
+
+- (void)setPage:(NSInteger)index {
+    CGPoint targetOffset = [self isHorizontal] ? CGPointMake(_scrollView.frame.size.width * index, 0) : CGPointMake(0, _scrollView.frame.size.height * index);
+    
+        [_scrollView setContentOffset:targetOffset animated:YES];
+}
+
+- (void)setPageWithoutAnimation:(NSInteger)index {
+    CGPoint targetOffset = [self isHorizontal] ? CGPointMake(_scrollView.frame.size.width * index, 0) : CGPointMake(0, _scrollView.frame.size.height * index);
+    
+    [_scrollView setContentOffset:targetOffset animated:NO];
+    
+    const auto strongEventEmitter = *std::dynamic_pointer_cast<const RNCViewPagerEventEmitter>(_eventEmitter);
+    
+    strongEventEmitter.onPageSelected(RNCViewPagerEventEmitter::OnPageSelected{.position =  static_cast<double>(index)});
 }
 
 #pragma mark - RCTComponentViewProtocol

--- a/ios/Fabric/RNCPagerViewComponentView.mm
+++ b/ios/Fabric/RNCPagerViewComponentView.mm
@@ -202,14 +202,18 @@ using namespace facebook::react;
     return [self isHorizontal] ? _scrollView.contentOffset.x / _scrollView.frame.size.width : _scrollView.contentOffset.y / _scrollView.frame.size.height;
 }
 
+-(CGPoint)getPageOffset:(NSInteger)pageIndex {
+    return [self isHorizontal] ? CGPointMake(_scrollView.frame.size.width * pageIndex, 0) : CGPointMake(0, _scrollView.frame.size.height * pageIndex);
+}
+
 - (void)setPage:(NSInteger)index {
-    CGPoint targetOffset = [self isHorizontal] ? CGPointMake(_scrollView.frame.size.width * index, 0) : CGPointMake(0, _scrollView.frame.size.height * index);
+    CGPoint targetOffset = [self getPageOffset:index];
     
     [_scrollView setContentOffset:targetOffset animated:YES];
 }
 
 - (void)setPageWithoutAnimation:(NSInteger)index {
-    CGPoint targetOffset = [self isHorizontal] ? CGPointMake(_scrollView.frame.size.width * index, 0) : CGPointMake(0, _scrollView.frame.size.height * index);
+    CGPoint targetOffset = [self getPageOffset:index];
     
     [_scrollView setContentOffset:targetOffset animated:NO];
     

--- a/ios/Fabric/RNCPagerViewComponentView.mm
+++ b/ios/Fabric/RNCPagerViewComponentView.mm
@@ -126,6 +126,12 @@ using namespace facebook::react;
 - (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
     [childComponentView removeFromSuperview];
+    
+    NSInteger numberOfPages = _containerView.subviews.count;
+
+    if ([self getCurrentPage] >= numberOfPages - 1) {
+        [self setPageWithoutAnimation: numberOfPages - 1];
+    }
 }
 
 - (void)handleCommand:(const NSString *)commandName args:(const NSArray *)args {

--- a/ios/Fabric/RNCPagerViewComponentView.mm
+++ b/ios/Fabric/RNCPagerViewComponentView.mm
@@ -91,7 +91,7 @@ using namespace facebook::react;
     _containerView.frame = CGRect{RCTCGPointFromPoint(data.contentBoundingRect.origin), contentSize};
     
     _scrollView.contentSize = contentSize;
- 
+    
 }
 
 - (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
@@ -150,7 +150,7 @@ using namespace facebook::react;
 -(void)scrollViewDidScroll:(UIScrollView *)scrollView {
     int position = [self getCurrentPage];
     
-    double offset = (scrollView.contentOffset.x - (scrollView.frame.size.width * position))/scrollView.frame.size.width;
+    double offset = [self isHorizontal] ? (scrollView.contentOffset.x - (scrollView.frame.size.width * position))/scrollView.frame.size.width : (scrollView.contentOffset.y - (scrollView.frame.size.height * position))/scrollView.frame.size.height;
     
     const auto strongEventEmitter = *std::dynamic_pointer_cast<const RNCViewPagerEventEmitter>(_eventEmitter);
     
@@ -178,7 +178,7 @@ using namespace facebook::react;
 - (void)setPage:(NSInteger)index {
     CGPoint targetOffset = [self isHorizontal] ? CGPointMake(_scrollView.frame.size.width * index, 0) : CGPointMake(0, _scrollView.frame.size.height * index);
     
-        [_scrollView setContentOffset:targetOffset animated:YES];
+    [_scrollView setContentOffset:targetOffset animated:YES];
 }
 
 - (void)setPageWithoutAnimation:(NSInteger)index {

--- a/ios/Fabric/RNCPagerViewComponentView.mm
+++ b/ios/Fabric/RNCPagerViewComponentView.mm
@@ -24,6 +24,7 @@ using namespace facebook::react;
     UIView *_containerView;
     
     CGSize _contentSize;
+    NSInteger _initialPage;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -31,6 +32,7 @@ using namespace facebook::react;
     if (self = [super initWithFrame:frame]) {
         static const auto defaultProps = std::make_shared<const RNCViewPagerProps>();
         _props = defaultProps;
+        _initialPage = -1;
         
         _scrollView = [[UIScrollView alloc] initWithFrame:self.bounds];
         
@@ -74,6 +76,9 @@ using namespace facebook::react;
 {
     assert(std::dynamic_pointer_cast<RNCViewPagerShadowNode::ConcreteState const>(state));
     _state = std::static_pointer_cast<RNCViewPagerShadowNode::ConcreteState const>(state);
+    
+    const auto &props = *std::static_pointer_cast<const RNCViewPagerProps>(_props);
+    
     auto &data = _state->getData();
     
     auto contentOffset = RCTCGPointFromPoint(data.contentOffset);
@@ -91,6 +96,11 @@ using namespace facebook::react;
     _containerView.frame = CGRect{RCTCGPointFromPoint(data.contentBoundingRect.origin), contentSize};
     
     _scrollView.contentSize = contentSize;
+    
+    if (!CGSizeEqualToSize(_scrollView.frame.size, CGSizeZero) && _initialPage == -1) {
+        [self setPageWithoutAnimation: props.initialPage];
+        _initialPage = props.initialPage;
+    }
     
 }
 
@@ -112,6 +122,9 @@ using namespace facebook::react;
 {
     _state.reset();
     [_scrollView setContentOffset:CGPointZero];
+    
+    _initialPage = -1;
+    
     [super prepareForRecycle];
 }
 

--- a/ios/Fabric/RNCPagerViewComponentView.mm
+++ b/ios/Fabric/RNCPagerViewComponentView.mm
@@ -72,6 +72,20 @@ using namespace facebook::react;
     [super updateProps:props oldProps:oldProps];
 }
 
+- (void)updateLayoutMetrics:(const LayoutMetrics &)layoutMetrics
+           oldLayoutMetrics:(const LayoutMetrics &)oldLayoutMetrics
+{
+    [super updateLayoutMetrics:layoutMetrics oldLayoutMetrics:oldLayoutMetrics];
+    if (layoutMetrics.layoutDirection != oldLayoutMetrics.layoutDirection) {
+        CGAffineTransform transform = (layoutMetrics.layoutDirection == LayoutDirection::LeftToRight)
+        ? CGAffineTransformIdentity
+        : CGAffineTransformMakeScale(-1, 1);
+        
+        _containerView.transform = transform;
+        _scrollView.transform = transform;
+    }
+}
+
 - (void)updateState:(State::Shared const &)state oldState:(State::Shared const &)oldState
 {
     assert(std::dynamic_pointer_cast<RNCViewPagerShadowNode::ConcreteState const>(state));

--- a/react-native-pager-view.podspec
+++ b/react-native-pager-view.podspec
@@ -31,6 +31,13 @@ Pod::Spec.new do |s|
     s.dependency "RCTRequired"
     s.dependency "RCTTypeSafety"
     s.dependency "ReactCommon/turbomodule/core"
+
+    s.subspec "common" do |ss|
+      ss.source_files         = "common/cpp/**/*.{cpp,h}"
+      ss.header_dir           = "RNCViewPager"
+      ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/common/cpp\"" }
+    end
+
     s.dependency "React-RCTFabric"
   end
 end

--- a/src/PagerView.tsx
+++ b/src/PagerView.tsx
@@ -152,6 +152,7 @@ export class PagerView extends React.Component<PagerViewProps> {
         style={[
           this.props.style,
           {
+            marginHorizontal: -this.props.pageMargin / 2,
             flexDirection:
               this.props.orientation === 'vertical' ? 'column' : 'row',
           },
@@ -161,7 +162,10 @@ export class PagerView extends React.Component<PagerViewProps> {
         onPageScrollStateChanged={this._onPageScrollStateChanged}
         onPageSelected={this._onPageSelected}
         onMoveShouldSetResponderCapture={this._onMoveShouldSetResponderCapture}
-        children={childrenWithOverriddenStyle(this.props.children)}
+        children={childrenWithOverriddenStyle(
+          this.props.children,
+          this.props.pageMargin
+        )}
       />
     );
   }

--- a/src/PagerView.tsx
+++ b/src/PagerView.tsx
@@ -151,8 +151,12 @@ export class PagerView extends React.Component<PagerViewProps> {
         }}
         style={[
           this.props.style,
+          this.props.pageMargin
+            ? {
+                marginHorizontal: -this.props.pageMargin / 2,
+              }
+            : null,
           {
-            marginHorizontal: -this.props.pageMargin / 2,
             flexDirection:
               this.props.orientation === 'vertical' ? 'column' : 'row',
           },

--- a/src/PagerView.tsx
+++ b/src/PagerView.tsx
@@ -149,7 +149,13 @@ export class PagerView extends React.Component<PagerViewProps> {
         ref={(ref) => {
           this.pagerView = ref;
         }}
-        style={this.props.style}
+        style={[
+          this.props.style,
+          {
+            flexDirection:
+              this.props.orientation === 'vertical' ? 'column' : 'row',
+          },
+        ]}
         layoutDirection={this.deducedLayoutDirection}
         onPageScroll={this._onPageScroll}
         onPageScrollStateChanged={this._onPageScrollStateChanged}

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -1,12 +1,22 @@
 import React, { Children, ReactNode } from 'react';
 import { View } from 'react-native';
 
-export const childrenWithOverriddenStyle = (children?: ReactNode) => {
+export const childrenWithOverriddenStyle = (
+  children?: ReactNode,
+  pageMargin = 0
+) => {
   return Children.map(children, (child) => {
     const element = child as React.ReactElement;
     return (
       // Add a wrapper to ensure layout is calculated correctly
-      <View style={{ height: '100%', width: '100%' }} collapsable={false}>
+      <View
+        style={{
+          height: '100%',
+          width: '100%',
+          paddingHorizontal: pageMargin / 2,
+        }}
+        collapsable={false}
+      >
         {React.cloneElement(element, {
           ...element.props,
           // Override styles so that each page will fill the parent.

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -1,17 +1,16 @@
 import React, { Children, ReactNode } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 
 export const childrenWithOverriddenStyle = (children?: ReactNode) => {
   return Children.map(children, (child) => {
     const element = child as React.ReactElement;
     return (
       // Add a wrapper to ensure layout is calculated correctly
-      <View style={StyleSheet.absoluteFill} collapsable={false}>
-        {/* @ts-ignore */}
+      <View style={{ height: '100%', width: '100%' }} collapsable={false}>
         {React.cloneElement(element, {
           ...element.props,
           // Override styles so that each page will fill the parent.
-          style: [element.props.style, StyleSheet.absoluteFill],
+          style: [element.props.style, { height: '100%', width: '100%' }],
         })}
       </View>
     );

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -6,9 +6,7 @@ export const childrenWithOverriddenStyle = (
   pageMargin = 0
 ) => {
   return Children.map(children, (child) => {
-    const element = child as React.ReactElement;
     return (
-      // Add a wrapper to ensure layout is calculated correctly
       <View
         style={{
           height: '100%',
@@ -17,11 +15,7 @@ export const childrenWithOverriddenStyle = (
         }}
         collapsable={false}
       >
-        {React.cloneElement(element, {
-          ...element.props,
-          // Override styles so that each page will fill the parent.
-          style: [element.props.style, { height: '100%', width: '100%' }],
-        })}
+        {child}
       </View>
     );
   });


### PR DESCRIPTION
# Summary

This PR introduces _PagerView_ **Fabric** implementation rewrite from **UIPageView** to **UIScrollView**.

It is based on React Native's **UIScrollView** implementation for  **Fabric**.

## Motivation

As described in #673, we wanted to have more control over native side of _PagerView_ which could be achieved by switching from using **UIPageViewController** to **UIScrollView**. 

This change makes _PagerView_ easier to maintain, because some solutions and workarounds used in previous implementation were adding more complexity and were causing some additional bugs. 

Switching to **UIScrollView** allowed to reduce amount of code and complexity, while maintaining same functionality.
In future it will also be easier to add new features or e.g. custom animations to _PagerView_.

## Test Plan

Every example should work as expected (only Fabric architecture)

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
