### PR TITLE
fix: adjust `canChildScroll` based on `scrollEnabled`

### DIFF
--- a/android/src/main/java/com/reactnativepagerview/NestedScrollableHost.kt
+++ b/android/src/main/java/com/reactnativepagerview/NestedScrollableHost.kt
@@ -43,6 +43,10 @@ class NestedScrollableHost : FrameLayout {
   }
 
   private fun canChildScroll(orientation: Int, delta: Float): Boolean {
+    if ((child as? ViewPager2)?.isUserInputEnabled == false) {
+      return false
+    }
+
     val direction = -delta.sign.toInt()
     return when (orientation) {
       0 -> child?.canScrollHorizontally(direction) ?: false


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

Currently when disabling scroll using the `scrollEnabled` prop, the pager still consumes user inputs on Android. This adjusts `NestedScrollableHost` such that that it no longer consumes touch events when `isUserInputEnabled` is disabled on the child pager by the `scrollEnabled` prop.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

A set up with two nested pagers aligned in the same direction on an Android device.

On iOS, expected behavior works correctly.

### What are the steps to reproduce (after prerequisites)?

Attempt to scroll a multi-page pager via touch when it's nested inside of another pager on the same axis in a direction where there's an available page. Previously, this would prevent both pagers from scrolling when the parent pager has `scrollEnabled=true` and the child pager has `scrollEnabled=false`. Now, it disables event handling on the child pager allowing the parent pager to scroll.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    N/A     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
