### PR TITLE
Fix safe area in examples

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -302,7 +302,7 @@ PODS:
   - React-jsinspector (0.70.5)
   - React-logger (0.70.5):
     - glog
-  - react-native-pager-view (6.1.4):
+  - react-native-pager-view (6.2.0):
     - React-Core
   - react-native-safe-area-context (3.4.1):
     - React-Core
@@ -618,7 +618,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 31564fa6912459921568e8b0e49024285a4d584b
   React-jsinspector: badd81696361249893a80477983e697aab3c1a34
   React-logger: fdda34dd285bdb0232e059b19d9606fa0ec3bb9c
-  react-native-pager-view: b58cb9e9f42f64e50cab3040815772c1d119a2e2
+  react-native-pager-view: 0ccb8bf60e2ebd38b1f3669fa3650ecce81db2df
   react-native-safe-area-context: 9e40fb181dac02619414ba1294d6c2a807056ab9
   React-perflogger: e68d3795cf5d247a0379735cbac7309adf2fb931
   React-RCTActionSheet: 05452c3b281edb27850253db13ecd4c5a65bc247
@@ -643,4 +643,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 7bb6ac2c486fd5b7d13ac3d8fc31d2174d38be56
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.12.0

--- a/example/package.json
+++ b/example/package.json
@@ -25,7 +25,7 @@
     "react-native-tab-view": "^3.1.1"
   },
   "resolutions": {
-    "@types/react": "17.0.21"
+    "@types/react": "18.0.29"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -30,6 +30,7 @@ import CustomTabBarExample from './tabView/CustomTabBarExample';
 import CoverflowExample from './tabView/CoverflowExample';
 import ReanimatedOnPageScrollExample from './ReanimatedOnPageScrollExample';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 const examples = [
   { component: BasicPagerViewExample, name: 'Basic Example' },
@@ -90,46 +91,48 @@ export function Navigation() {
   const [mode, setMode] = React.useState<'native' | 'js'>('native');
   const NavigationStack = mode === 'js' ? Stack : NativeStack;
   return (
-    <NavigationContainer>
-      <NavigationStack.Navigator initialRouteName="PagerView Example">
-        <NavigationStack.Screen
-          name="PagerView Example"
-          component={App}
-          options={{
-            headerRight: () => (
-              <Button
-                onPress={() =>
-                  Alert.alert(
-                    'Alert',
-                    `Do you want to change to the ${
-                      mode === 'js' ? 'native stack' : 'js stack'
-                    } ?`,
-                    [
-                      { text: 'No', onPress: () => {} },
-                      {
-                        text: 'Yes',
-                        onPress: () => {
-                          setMode(mode === 'js' ? 'native' : 'js');
-                        },
-                      },
-                    ]
-                  )
-                }
-                title={mode === 'js' ? 'JS' : 'NATIVE'}
-                color="orange"
-              />
-            ),
-          }}
-        />
-        {examples.map((example, index) => (
+    <SafeAreaProvider>
+      <NavigationContainer>
+        <NavigationStack.Navigator initialRouteName="PagerView Example">
           <NavigationStack.Screen
-            key={index}
-            name={example.name}
-            component={example.component}
+            name="PagerView Example"
+            component={App}
+            options={{
+              headerRight: () => (
+                <Button
+                  onPress={() =>
+                    Alert.alert(
+                      'Alert',
+                      `Do you want to change to the ${
+                        mode === 'js' ? 'native stack' : 'js stack'
+                      } ?`,
+                      [
+                        { text: 'No', onPress: () => {} },
+                        {
+                          text: 'Yes',
+                          onPress: () => {
+                            setMode(mode === 'js' ? 'native' : 'js');
+                          },
+                        },
+                      ]
+                    )
+                  }
+                  title={mode === 'js' ? 'JS' : 'NATIVE'}
+                  color="orange"
+                />
+              ),
+            }}
           />
-        ))}
-      </NavigationStack.Navigator>
-    </NavigationContainer>
+          {examples.map((example, index) => (
+            <NavigationStack.Screen
+              key={index}
+              name={example.name}
+              component={example.component}
+            />
+          ))}
+        </NavigationStack.Navigator>
+      </NavigationContainer>
+    </SafeAreaProvider>
   );
 }
 

--- a/example/src/ScrollablePagerViewExample.tsx
+++ b/example/src/ScrollablePagerViewExample.tsx
@@ -3,16 +3,25 @@ import React from 'react';
 import { ScrollView, View, Image, StyleSheet, Animated } from 'react-native';
 import { NavigationPanel } from './component/NavigationPanel';
 import { useNavigationPanel } from './hook/useNavigationPanel';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 const HEIGHT = 300;
 
 const AnimatedPagerView = Animated.createAnimatedComponent(PagerView);
 
-export const ScrollablePagerViewExample = (): JSX.Element => {
+export function ScrollablePagerViewExample() {
   const { ref, ...navigationPanel } = useNavigationPanel();
+  const insets = useSafeAreaInsets();
 
   return (
-    <>
+    <View
+      style={{
+        flex: 1,
+        paddingBottom: insets.bottom,
+        paddingLeft: insets.left,
+        paddingRight: insets.right,
+      }}
+    >
       <ScrollView style={styles.flex}>
         {navigationPanel.pages.map(({ key }) => (
           <AnimatedPagerView
@@ -30,9 +39,9 @@ export const ScrollablePagerViewExample = (): JSX.Element => {
         ))}
       </ScrollView>
       <NavigationPanel {...navigationPanel} />
-    </>
+    </View>
   );
-};
+}
 
 const styles = StyleSheet.create({
   flex: {

--- a/example/src/tabView/CustomIndicatorExample.tsx
+++ b/example/src/tabView/CustomIndicatorExample.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Animated, View, Text, StyleSheet, I18nManager } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   TabView,
   TabBar,
@@ -17,32 +18,25 @@ type Route = {
 
 type State = NavigationState<Route>;
 
-export default class CustomIndicatorExample extends React.Component<{}, State> {
-  static title = 'Custom indicator';
-  static backgroundColor = '#263238';
-  static appbarElevation = 4;
+export default function CustomIndicatorExample() {
+  const [index, setIndex] = React.useState(0);
+  const routes = [
+    {
+      key: 'article',
+    },
+    {
+      key: 'contacts',
+    },
+    {
+      key: 'albums',
+    },
+  ];
 
-  state: State = {
-    index: 0,
-    routes: [
-      {
-        key: 'article',
-      },
-      {
-        key: 'contacts',
-      },
-      {
-        key: 'albums',
-      },
-    ],
-  };
+  const insets = useSafeAreaInsets();
 
-  private handleIndexChange = (index: number) =>
-    this.setState({
-      index,
-    });
+  const handleIndexChange = (index: number) => setIndex(index);
 
-  private renderIndicator = (
+  const renderIndicator = (
     props: SceneRendererProps & {
       navigationState: State;
       getTabWidth: (i: number) => number;
@@ -90,20 +84,20 @@ export default class CustomIndicatorExample extends React.Component<{}, State> {
           styles.container,
           {
             width: `${100 / navigationState.routes.length}%`,
-            transform: [{ translateX }] as any,
+            transform: [{ translateX }],
           },
         ]}
       >
         <Animated.View
-          style={[styles.indicator, { opacity, transform: [{ scale }] } as any]}
+          style={[styles.indicator, { opacity, transform: [{ scale }] }]}
         />
       </Animated.View>
     );
   };
 
-  private renderIcon = () => null;
+  const renderIcon = () => null;
 
-  private renderBadge = ({ route }: { route: Route }) => {
+  const renderBadge = ({ route }: { route: Route }) => {
     if (route.key === 'albums') {
       return (
         <View style={styles.badge}>
@@ -114,35 +108,42 @@ export default class CustomIndicatorExample extends React.Component<{}, State> {
     return null;
   };
 
-  private renderTabBar = (
+  const renderTabBar = (
     props: SceneRendererProps & { navigationState: State }
   ) => (
     <TabBar
       {...props}
-      renderIcon={this.renderIcon}
-      renderBadge={this.renderBadge}
-      renderIndicator={this.renderIndicator}
+      renderIcon={renderIcon}
+      renderBadge={renderBadge}
+      renderIndicator={renderIndicator}
       style={styles.tabbar}
     />
   );
 
-  private renderScene = SceneMap({
+  const renderScene = SceneMap({
     article: Article,
     contacts: Contacts,
     albums: Albums,
   });
 
-  render() {
-    return (
+  return (
+    <View
+      style={{
+        flex: 1,
+        paddingBottom: insets.bottom,
+        paddingLeft: insets.left,
+        paddingRight: insets.right,
+      }}
+    >
       <TabView
-        navigationState={this.state}
-        renderScene={this.renderScene}
-        renderTabBar={this.renderTabBar}
+        navigationState={{ index, routes }}
+        renderScene={renderScene}
+        renderTabBar={renderTabBar}
         tabBarPosition="bottom"
-        onIndexChange={this.handleIndexChange}
+        onIndexChange={handleIndexChange}
       />
-    );
-  }
+    </View>
+  );
 }
 
 const styles = StyleSheet.create({

--- a/example/src/tabView/CustomIndicatorExample.tsx
+++ b/example/src/tabView/CustomIndicatorExample.tsx
@@ -18,23 +18,21 @@ type Route = {
 
 type State = NavigationState<Route>;
 
+const routes = [
+  {
+    key: 'article',
+  },
+  {
+    key: 'contacts',
+  },
+  {
+    key: 'albums',
+  },
+];
+
 export default function CustomIndicatorExample() {
   const [index, setIndex] = React.useState(0);
-  const routes = [
-    {
-      key: 'article',
-    },
-    {
-      key: 'contacts',
-    },
-    {
-      key: 'albums',
-    },
-  ];
-
   const insets = useSafeAreaInsets();
-
-  const handleIndexChange = (index: number) => setIndex(index);
 
   const renderIndicator = (
     props: SceneRendererProps & {
@@ -140,7 +138,7 @@ export default function CustomIndicatorExample() {
         renderScene={renderScene}
         renderTabBar={renderTabBar}
         tabBarPosition="bottom"
-        onIndexChange={handleIndexChange}
+        onIndexChange={setIndex}
       />
     </View>
   );

--- a/example/src/tabView/CustomTabBarExample.tsx
+++ b/example/src/tabView/CustomTabBarExample.tsx
@@ -25,18 +25,17 @@ type Route = {
 
 type State = NavigationState<Route>;
 
+const routes = [
+  { key: 'contacts', title: 'Contacts' },
+  { key: 'albums', title: 'Albums' },
+  { key: 'article', title: 'Article' },
+  { key: 'chat', title: 'Chat' },
+];
+
 export default function CustomTabBarExample() {
-  const routes = [
-    { key: 'contacts', title: 'Contacts' },
-    { key: 'albums', title: 'Albums' },
-    { key: 'article', title: 'Article' },
-    { key: 'chat', title: 'Chat' },
-  ];
   const [index, setIndex] = React.useState(0);
 
   const insets = useSafeAreaInsets();
-
-  const handleIndexChange = (index: number) => setIndex(index);
 
   const renderItem = ({
     navigationState,
@@ -110,15 +109,13 @@ export default function CustomTabBarExample() {
         renderScene={renderScene}
         renderTabBar={renderTabBar}
         tabBarPosition="bottom"
-        onIndexChange={handleIndexChange}
+        onIndexChange={setIndex}
       />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {},
-
   tabbar: {
     flexDirection: 'row',
     justifyContent: 'space-between',

--- a/example/src/tabView/CustomTabBarExample.tsx
+++ b/example/src/tabView/CustomTabBarExample.tsx
@@ -6,6 +6,7 @@ import {
   TouchableWithoutFeedback,
   StyleSheet,
 } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   TabView,
   SceneMap,
@@ -24,29 +25,20 @@ type Route = {
 
 type State = NavigationState<Route>;
 
-export default class CustomTabBarExample extends React.Component<{}, State> {
-  static title = 'Custom tab bar';
-  static backgroundColor = '#fafafa';
-  static tintColor = '#263238';
-  static appbarElevation = 4;
-  static statusBarStyle = 'dark-content' as 'dark-content';
+export default function CustomTabBarExample() {
+  const routes = [
+    { key: 'contacts', title: 'Contacts' },
+    { key: 'albums', title: 'Albums' },
+    { key: 'article', title: 'Article' },
+    { key: 'chat', title: 'Chat' },
+  ];
+  const [index, setIndex] = React.useState(0);
 
-  state: State = {
-    index: 0,
-    routes: [
-      { key: 'contacts', title: 'Contacts' },
-      { key: 'albums', title: 'Albums' },
-      { key: 'article', title: 'Article' },
-      { key: 'chat', title: 'Chat' },
-    ],
-  };
+  const insets = useSafeAreaInsets();
 
-  private handleIndexChange = (index: number) =>
-    this.setState({
-      index,
-    });
+  const handleIndexChange = (index: number) => setIndex(index);
 
-  private renderItem = ({
+  const renderItem = ({
     navigationState,
     position,
   }: {
@@ -80,7 +72,7 @@ export default class CustomTabBarExample extends React.Component<{}, State> {
     );
   };
 
-  private renderTabBar = (
+  const renderTabBar = (
     props: SceneRendererProps & { navigationState: State }
   ) => (
     <View style={styles.tabbar}>
@@ -90,34 +82,43 @@ export default class CustomTabBarExample extends React.Component<{}, State> {
             key={route.key}
             onPress={() => props.jumpTo(route.key)}
           >
-            {this.renderItem(props)({ route, index })}
+            {renderItem(props)({ route, index })}
           </TouchableWithoutFeedback>
         );
       })}
     </View>
   );
 
-  private renderScene = SceneMap({
+  const renderScene = SceneMap({
     contacts: Contacts,
     albums: Albums,
     article: Article,
     chat: Chat,
   });
 
-  render() {
-    return (
+  return (
+    <View
+      style={{
+        flex: 1,
+        paddingBottom: insets.bottom,
+        paddingLeft: insets.left,
+        paddingRight: insets.right,
+      }}
+    >
       <TabView
-        navigationState={this.state}
-        renderScene={this.renderScene}
-        renderTabBar={this.renderTabBar}
+        navigationState={{ index, routes }}
+        renderScene={renderScene}
+        renderTabBar={renderTabBar}
         tabBarPosition="bottom"
-        onIndexChange={this.handleIndexChange}
+        onIndexChange={handleIndexChange}
       />
-    );
-  }
+    </View>
+  );
 }
 
 const styles = StyleSheet.create({
+  container: {},
+
   tabbar: {
     flexDirection: 'row',
     justifyContent: 'space-between',

--- a/example/src/tabView/TabBarIconExample.tsx
+++ b/example/src/tabView/TabBarIconExample.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { StyleSheet } from 'react-native';
+import { StyleSheet, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   TabView,
   TabBar,
@@ -13,57 +14,61 @@ import Contacts from './Shared/Contacts';
 
 type Route = {
   key: string;
+  title: string;
 };
 
 type State = NavigationState<Route>;
 
-export default class TabBarIconExample extends React.Component<{}, State> {
-  static title = 'Top tab bar with icons';
-  static backgroundColor = '#e91e63';
-  static appbarElevation = 0;
+export default function TabBarIconExample() {
+  const [index, setIndex] = React.useState(0);
+  const routes = [
+    { key: 'chat', title: 'Chat' },
+    { key: 'contacts', title: 'Contacts' },
+    { key: 'article', title: 'Article' },
+  ];
+  const insets = useSafeAreaInsets();
 
-  state: State = {
-    index: 0,
-    routes: [{ key: 'chat' }, { key: 'contacts' }, { key: 'article' }],
-  };
+  const handleIndexChange = (index: number) => setIndex(index);
 
-  private handleIndexChange = (index: number) =>
-    this.setState({
-      index,
-    });
+  const renderIcon = () => null;
 
-  private renderIcon = () => null;
-
-  private renderTabBar = (
+  const renderTabBar = (
     props: SceneRendererProps & { navigationState: State }
   ) => {
     return (
       <TabBar
         {...props}
         indicatorStyle={styles.indicator}
-        renderIcon={this.renderIcon}
+        renderIcon={renderIcon}
         style={styles.tabbar}
       />
     );
   };
 
-  private renderScene = SceneMap({
+  const renderScene = SceneMap({
     chat: Chat,
     contacts: Contacts,
     article: Article,
   });
 
-  render() {
-    return (
+  return (
+    <View
+      style={{
+        flex: 1,
+        paddingBottom: insets.bottom,
+        paddingLeft: insets.left,
+        paddingRight: insets.right,
+      }}
+    >
       <TabView
         lazy
-        navigationState={this.state}
-        renderScene={this.renderScene}
-        renderTabBar={this.renderTabBar}
-        onIndexChange={this.handleIndexChange}
+        navigationState={{ index, routes }}
+        renderScene={renderScene}
+        renderTabBar={renderTabBar}
+        onIndexChange={handleIndexChange}
       />
-    );
-  }
+    </View>
+  );
 }
 
 const styles = StyleSheet.create({

--- a/example/src/tabView/TabBarIconExample.tsx
+++ b/example/src/tabView/TabBarIconExample.tsx
@@ -19,16 +19,15 @@ type Route = {
 
 type State = NavigationState<Route>;
 
+const routes = [
+  { key: 'chat', title: 'Chat' },
+  { key: 'contacts', title: 'Contacts' },
+  { key: 'article', title: 'Article' },
+];
+
 export default function TabBarIconExample() {
   const [index, setIndex] = React.useState(0);
-  const routes = [
-    { key: 'chat', title: 'Chat' },
-    { key: 'contacts', title: 'Contacts' },
-    { key: 'article', title: 'Article' },
-  ];
   const insets = useSafeAreaInsets();
-
-  const handleIndexChange = (index: number) => setIndex(index);
 
   const renderIcon = () => null;
 
@@ -65,7 +64,7 @@ export default function TabBarIconExample() {
         navigationState={{ index, routes }}
         renderScene={renderScene}
         renderTabBar={renderTabBar}
-        onIndexChange={handleIndexChange}
+        onIndexChange={setIndex}
       />
     </View>
   );

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1421,10 +1421,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@17.0.21":
-  version "17.0.21"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.21.tgz#069c43177cd419afaab5ce26bb4e9056549f7ea6"
-  integrity sha512-GzzXCpOthOjXvrAUFQwU/svyxu658cwu00Q9ugujS4qc1zXgLFaO0kS2SLOaMWLt2Jik781yuHCWB7UcYdGAeQ==
+"@types/react@*", "@types/react@18.0.29":
+  version "18.0.29"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.29.tgz#4cead505172c0020c5b51940199e31fc6ff2f63a"
+  integrity sha512-wXHktgUABxplw1+UnljseDq4+uztQyp2tlWZRIxHlpchsCFqiYkvaDS8JR7eKOQm8wziTH/el5qL7D6gYNkYcw==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"

--- a/fabricexample/package.json
+++ b/fabricexample/package.json
@@ -24,7 +24,7 @@
     "react-native-tab-view": "^3.3.0"
   },
   "resolutions": {
-    "@types/react": "17.0.21"
+    "@types/react": "18.0.29"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",

--- a/fabricexample/src/tabView/CustomIndicatorExample.tsx
+++ b/fabricexample/src/tabView/CustomIndicatorExample.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Animated, View, Text, StyleSheet, I18nManager } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   TabView,
   TabBar,
@@ -17,32 +18,23 @@ type Route = {
 
 type State = NavigationState<Route>;
 
-export default class CustomIndicatorExample extends React.Component<{}, State> {
-  static title = 'Custom indicator';
-  static backgroundColor = '#263238';
-  static appbarElevation = 4;
+const routes = [
+  {
+    key: 'article',
+  },
+  {
+    key: 'contacts',
+  },
+  {
+    key: 'albums',
+  },
+];
 
-  state: State = {
-    index: 0,
-    routes: [
-      {
-        key: 'article',
-      },
-      {
-        key: 'contacts',
-      },
-      {
-        key: 'albums',
-      },
-    ],
-  };
+export default function CustomIndicatorExample() {
+  const [index, setIndex] = React.useState(0);
+  const insets = useSafeAreaInsets();
 
-  private handleIndexChange = (index: number) =>
-    this.setState({
-      index,
-    });
-
-  private renderIndicator = (
+  const renderIndicator = (
     props: SceneRendererProps & {
       navigationState: State;
       getTabWidth: (i: number) => number;
@@ -90,20 +82,20 @@ export default class CustomIndicatorExample extends React.Component<{}, State> {
           styles.container,
           {
             width: `${100 / navigationState.routes.length}%`,
-            transform: [{ translateX }] as any,
+            transform: [{ translateX }],
           },
         ]}
       >
         <Animated.View
-          style={[styles.indicator, { opacity, transform: [{ scale }] } as any]}
+          style={[styles.indicator, { opacity, transform: [{ scale }] }]}
         />
       </Animated.View>
     );
   };
 
-  private renderIcon = () => null;
+  const renderIcon = () => null;
 
-  private renderBadge = ({ route }: { route: Route }) => {
+  const renderBadge = ({ route }: { route: Route }) => {
     if (route.key === 'albums') {
       return (
         <View style={styles.badge}>
@@ -114,35 +106,42 @@ export default class CustomIndicatorExample extends React.Component<{}, State> {
     return null;
   };
 
-  private renderTabBar = (
+  const renderTabBar = (
     props: SceneRendererProps & { navigationState: State }
   ) => (
     <TabBar
       {...props}
-      renderIcon={this.renderIcon}
-      renderBadge={this.renderBadge}
-      renderIndicator={this.renderIndicator}
+      renderIcon={renderIcon}
+      renderBadge={renderBadge}
+      renderIndicator={renderIndicator}
       style={styles.tabbar}
     />
   );
 
-  private renderScene = SceneMap({
+  const renderScene = SceneMap({
     article: Article,
     contacts: Contacts,
     albums: Albums,
   });
 
-  render() {
-    return (
+  return (
+    <View
+      style={{
+        flex: 1,
+        paddingBottom: insets.bottom,
+        paddingLeft: insets.left,
+        paddingRight: insets.right,
+      }}
+    >
       <TabView
-        navigationState={this.state}
-        renderScene={this.renderScene}
-        renderTabBar={this.renderTabBar}
+        navigationState={{ index, routes }}
+        renderScene={renderScene}
+        renderTabBar={renderTabBar}
         tabBarPosition="bottom"
-        onIndexChange={this.handleIndexChange}
+        onIndexChange={setIndex}
       />
-    );
-  }
+    </View>
+  );
 }
 
 const styles = StyleSheet.create({

--- a/fabricexample/src/tabView/CustomTabBarExample.tsx
+++ b/fabricexample/src/tabView/CustomTabBarExample.tsx
@@ -6,6 +6,7 @@ import {
   TouchableWithoutFeedback,
   StyleSheet,
 } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   TabView,
   SceneMap,
@@ -24,29 +25,19 @@ type Route = {
 
 type State = NavigationState<Route>;
 
-export default class CustomTabBarExample extends React.Component<{}, State> {
-  static title = 'Custom tab bar';
-  static backgroundColor = '#fafafa';
-  static tintColor = '#263238';
-  static appbarElevation = 4;
-  static statusBarStyle = 'dark-content' as 'dark-content';
+const routes = [
+  { key: 'contacts', title: 'Contacts' },
+  { key: 'albums', title: 'Albums' },
+  { key: 'article', title: 'Article' },
+  { key: 'chat', title: 'Chat' },
+];
 
-  state: State = {
-    index: 0,
-    routes: [
-      { key: 'contacts', title: 'Contacts' },
-      { key: 'albums', title: 'Albums' },
-      { key: 'article', title: 'Article' },
-      { key: 'chat', title: 'Chat' },
-    ],
-  };
+export default function CustomTabBarExample() {
+  const [index, setIndex] = React.useState(0);
 
-  private handleIndexChange = (index: number) =>
-    this.setState({
-      index,
-    });
+  const insets = useSafeAreaInsets();
 
-  private renderItem = ({
+  const renderItem = ({
     navigationState,
     position,
   }: {
@@ -80,7 +71,7 @@ export default class CustomTabBarExample extends React.Component<{}, State> {
     );
   };
 
-  private renderTabBar = (
+  const renderTabBar = (
     props: SceneRendererProps & { navigationState: State }
   ) => (
     <View style={styles.tabbar}>
@@ -90,31 +81,38 @@ export default class CustomTabBarExample extends React.Component<{}, State> {
             key={route.key}
             onPress={() => props.jumpTo(route.key)}
           >
-            {this.renderItem(props)({ route, index })}
+            {renderItem(props)({ route, index })}
           </TouchableWithoutFeedback>
         );
       })}
     </View>
   );
 
-  private renderScene = SceneMap({
+  const renderScene = SceneMap({
     contacts: Contacts,
     albums: Albums,
     article: Article,
     chat: Chat,
   });
 
-  render() {
-    return (
+  return (
+    <View
+      style={{
+        flex: 1,
+        paddingBottom: insets.bottom,
+        paddingLeft: insets.left,
+        paddingRight: insets.right,
+      }}
+    >
       <TabView
-        navigationState={this.state}
-        renderScene={this.renderScene}
-        renderTabBar={this.renderTabBar}
+        navigationState={{ index, routes }}
+        renderScene={renderScene}
+        renderTabBar={renderTabBar}
         tabBarPosition="bottom"
-        onIndexChange={this.handleIndexChange}
+        onIndexChange={setIndex}
       />
-    );
-  }
+    </View>
+  );
 }
 
 const styles = StyleSheet.create({

--- a/fabricexample/src/tabView/TabBarIconExample.tsx
+++ b/fabricexample/src/tabView/TabBarIconExample.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { StyleSheet } from 'react-native';
+import { StyleSheet, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   TabView,
   TabBar,
@@ -13,57 +14,60 @@ import Contacts from './Shared/Contacts';
 
 type Route = {
   key: string;
+  title: string;
 };
 
 type State = NavigationState<Route>;
 
-export default class TabBarIconExample extends React.Component<{}, State> {
-  static title = 'Top tab bar with icons';
-  static backgroundColor = '#e91e63';
-  static appbarElevation = 0;
+const routes = [
+  { key: 'chat', title: 'Chat' },
+  { key: 'contacts', title: 'Contacts' },
+  { key: 'article', title: 'Article' },
+];
 
-  state: State = {
-    index: 0,
-    routes: [{ key: 'chat' }, { key: 'contacts' }, { key: 'article' }],
-  };
+export default function TabBarIconExample() {
+  const [index, setIndex] = React.useState(0);
+  const insets = useSafeAreaInsets();
 
-  private handleIndexChange = (index: number) =>
-    this.setState({
-      index,
-    });
+  const renderIcon = () => null;
 
-  private renderIcon = () => null;
-
-  private renderTabBar = (
+  const renderTabBar = (
     props: SceneRendererProps & { navigationState: State }
   ) => {
     return (
       <TabBar
         {...props}
         indicatorStyle={styles.indicator}
-        renderIcon={this.renderIcon}
+        renderIcon={renderIcon}
         style={styles.tabbar}
       />
     );
   };
 
-  private renderScene = SceneMap({
+  const renderScene = SceneMap({
     chat: Chat,
     contacts: Contacts,
     article: Article,
   });
 
-  render() {
-    return (
+  return (
+    <View
+      style={{
+        flex: 1,
+        paddingBottom: insets.bottom,
+        paddingLeft: insets.left,
+        paddingRight: insets.right,
+      }}
+    >
       <TabView
         lazy
-        navigationState={this.state}
-        renderScene={this.renderScene}
-        renderTabBar={this.renderTabBar}
-        onIndexChange={this.handleIndexChange}
+        navigationState={{ index, routes }}
+        renderScene={renderScene}
+        renderTabBar={renderTabBar}
+        onIndexChange={setIndex}
       />
-    );
-  }
+    </View>
+  );
 }
 
 const styles = StyleSheet.create({

--- a/fabricexample/yarn.lock
+++ b/fabricexample/yarn.lock
@@ -1151,10 +1151,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@17.0.21":
-  version "17.0.21"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.21.tgz#069c43177cd419afaab5ce26bb4e9056549f7ea6"
-  integrity sha512-GzzXCpOthOjXvrAUFQwU/svyxu658cwu00Q9ugujS4qc1zXgLFaO0kS2SLOaMWLt2Jik781yuHCWB7UcYdGAeQ==
+"@types/react@*", "@types/react@18.0.29":
+  version "18.0.29"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.29.tgz#4cead505172c0020c5b51940199e31fc6ff2f63a"
+  integrity sha512-wXHktgUABxplw1+UnljseDq4+uztQyp2tlWZRIxHlpchsCFqiYkvaDS8JR7eKOQm8wziTH/el5qL7D6gYNkYcw==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@react-native-community/eslint-config": "^3.0.2",
     "@release-it/conventional-changelog": "^2.0.0",
     "@types/jest": "^28.1.2",
-    "@types/react": "17.0.21",
+    "@types/react": "18.0.29",
     "@types/react-native": "0.70.0",
     "eslint": "^8.4.1",
     "eslint-config-prettier": "^8.5.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "typescript": "^4.5.2"
   },
   "resolutions": {
-    "@types/react": "17.0.21"
+    "@types/react": "18.0.29"
   },
   "peerDependencies": {
     "react": "*",

--- a/src/PagerView.tsx
+++ b/src/PagerView.tsx
@@ -147,6 +147,7 @@ export class PagerView extends React.Component<PagerViewProps> {
       <PagerViewView
         {...this.props}
         ref={(ref) => {
+          //@ts-ignore fix it
           this.pagerView = ref;
         }}
         style={this.props.style}

--- a/src/PagerView.tsx
+++ b/src/PagerView.tsx
@@ -147,7 +147,6 @@ export class PagerView extends React.Component<PagerViewProps> {
       <PagerViewView
         {...this.props}
         ref={(ref) => {
-          //@ts-ignore fix it
           this.pagerView = ref;
         }}
         style={this.props.style}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2470,7 +2470,16 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@17.0.21":
+"@types/react@*", "@types/react@18.0.29":
+  version "18.0.29"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.29.tgz#4cead505172c0020c5b51940199e31fc6ff2f63a"
+  integrity sha512-wXHktgUABxplw1+UnljseDq4+uztQyp2tlWZRIxHlpchsCFqiYkvaDS8JR7eKOQm8wziTH/el5qL7D6gYNkYcw==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@17.0.21":
   version "17.0.21"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.21.tgz#069c43177cd419afaab5ce26bb4e9056549f7ea6"
   integrity sha512-GzzXCpOthOjXvrAUFQwU/svyxu658cwu00Q9ugujS4qc1zXgLFaO0kS2SLOaMWLt2Jik781yuHCWB7UcYdGAeQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2479,15 +2479,6 @@
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
-"@types/react@17.0.21":
-  version "17.0.21"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.21.tgz#069c43177cd419afaab5ce26bb4e9056549f7ea6"
-  integrity sha512-GzzXCpOthOjXvrAUFQwU/svyxu658cwu00Q9ugujS4qc1zXgLFaO0kS2SLOaMWLt2Jik781yuHCWB7UcYdGAeQ==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
 "@types/responselike@*", "@types/responselike@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/responselike/-/responselike-1.0.0.tgz#251f4fe7d154d2bad125abe1b429b23afd262e29"


### PR DESCRIPTION
# Summary

Fixes incorrect safe area for iOS examples.
Aditionally, updates "@types/react" as it was on older version which resulted in type errors. iOS pod for react-native-pager-view was bumped to latest version.

## Test Plan

Check if modified examples are working correctly on Android and iOS

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [X] I updated the typed files (TS and Flow)
