### PR TITLE
Fix issues reported by QA

### DIFF
--- a/example/src/KeyboardExample.tsx
+++ b/example/src/KeyboardExample.tsx
@@ -29,7 +29,7 @@ const Page = ({ title, description, onPress, buttonTitle }: PageProps) => {
     <>
       <Text style={styles.sectionTitle}>{title}</Text>
       <Text style={styles.sectionDescription}>{description}</Text>
-      <TextInput style={styles.textInput} />
+      <TextInput testID="text-input" style={styles.textInput} />
       <Button onPress={onPress} title={buttonTitle} />
     </>
   );

--- a/example/src/component/NavigationPanel/LogsPanel.tsx
+++ b/example/src/component/NavigationPanel/LogsPanel.tsx
@@ -8,7 +8,6 @@ export function LogsPanel({ logs }: LogsPanelProps) {
   return (
     <FlatList
       style={styles.container}
-      keyExtractor={({ timestamp }) => `${timestamp.getTime()}`}
       data={logs}
       renderItem={({ item }) => (
         //@ts-ignore

--- a/example/src/component/NavigationPanel/NavigationPanel.tsx
+++ b/example/src/component/NavigationPanel/NavigationPanel.tsx
@@ -48,7 +48,6 @@ export function NavigationPanel(props: NavigationPanelProps) {
           ]}
           activeOpacity={0.8}
           onPress={() => {
-            console.log('edek');
             setVisible((prevVisible) =>
               prevVisible === VisibleTab.Logs
                 ? VisibleTab.None

--- a/example/src/component/NavigationPanel/NavigationPanel.tsx
+++ b/example/src/component/NavigationPanel/NavigationPanel.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
-import { StyleSheet, Text, View } from 'react-native';
-import { TouchableOpacity } from 'react-native-gesture-handler';
+import { StyleSheet, Text, View, TouchableOpacity } from 'react-native';
 import { ControlsPanel } from './ControlPanel';
 import { LogsPanel } from './LogsPanel';
 import type { NavigationPanelProps } from './types';
@@ -48,13 +47,14 @@ export function NavigationPanel(props: NavigationPanelProps) {
             visible === VisibleTab.Logs && styles.toggleVisibilityButtonActive,
           ]}
           activeOpacity={0.8}
-          onPress={() =>
+          onPress={() => {
+            console.log('edek');
             setVisible((prevVisible) =>
               prevVisible === VisibleTab.Logs
                 ? VisibleTab.None
                 : VisibleTab.Logs
-            )
-          }
+            );
+          }}
         >
           <Text
             style={[
@@ -97,37 +97,5 @@ const styles = StyleSheet.create({
   },
   toggleVisibilityTextActive: {
     color: '#000',
-  },
-  buttons: {
-    flexDirection: 'row',
-    backgroundColor: 'black',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-  },
-  hiddenContainer: {
-    height: 0,
-    overflow: 'hidden',
-  },
-  buttonAdjustment: {
-    flex: 1,
-  },
-  progress: {
-    flexDirection: 'row',
-    height: 40,
-    backgroundColor: 'black',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-  },
-  buttonText: {
-    color: 'white',
-    paddingHorizontal: 20,
-  },
-  scrollState: {
-    flex: 1,
-    justifyContent: 'flex-end',
-  },
-  scrollStateText: {
-    color: '#99d1b7',
-    textAlign: 'center',
   },
 });

--- a/example/src/hook/useNavigationPanel.ts
+++ b/example/src/hook/useNavigationPanel.ts
@@ -54,10 +54,14 @@ export function useNavigationPanel(
     () => setPages((prevPages) => [...prevPages, createPage(prevPages.length)]),
     []
   );
-  const removePage = useCallback(
-    () => setPages((prevPages) => prevPages.slice(0, prevPages.length - 1)),
-    []
-  );
+  const removePage = useCallback(() => {
+    setPages((prevPages) => {
+      if (prevPages.length === 1) {
+        return prevPages;
+      }
+      return prevPages.slice(0, prevPages.length - 1);
+    });
+  }, []);
   const toggleAnimation = useCallback(
     () => setIsAnimated((animated) => !animated),
     []

--- a/fabricexample/ios/Podfile.lock
+++ b/fabricexample/ios/Podfile.lock
@@ -625,7 +625,7 @@ PODS:
   - React-jsinspector (0.70.5)
   - React-logger (0.70.5):
     - glog
-  - react-native-pager-view (6.1.1):
+  - react-native-pager-view (6.2.0):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -728,7 +728,7 @@ PODS:
     - React-jsi (= 0.70.5)
     - React-logger (= 0.70.5)
     - React-perflogger (= 0.70.5)
-  - RNGestureHandler (2.7.1):
+  - RNGestureHandler (2.9.0):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -1013,7 +1013,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 31564fa6912459921568e8b0e49024285a4d584b
   React-jsinspector: badd81696361249893a80477983e697aab3c1a34
   React-logger: fdda34dd285bdb0232e059b19d9606fa0ec3bb9c
-  react-native-pager-view: 22ef94ca5a46cb18e4573ed3e179f4f84d477490
+  react-native-pager-view: 03aa0e1580050c4a47ff8ac07f43d094057be562
   react-native-safe-area-context: 2f75b317784a1a8e224562941e50ecbc932d2097
   React-perflogger: e68d3795cf5d247a0379735cbac7309adf2fb931
   React-RCTActionSheet: 05452c3b281edb27850253db13ecd4c5a65bc247
@@ -1029,7 +1029,7 @@ SPEC CHECKSUMS:
   React-rncore: e2856a5f65ec840ffe2dfdc14ac84e1ee1a18c25
   React-runtimeexecutor: 7401c4a40f8728fd89df4a56104541b760876117
   ReactCommon: c9246996e73bf75a2c6c3ff15f1e16707cdc2da9
-  RNGestureHandler: 8e5218fe0fde045c6f318202fc51ce3638deee54
+  RNGestureHandler: 9d2ebd17a9fef618d9720e3d95ff5e6607acf8d4
   RNReanimated: bba951bc75426d2f34d26ce5ec8ca6b8eba5f252
   RNScreens: 208223c783496e6d0aa92ffdf307f61d58756fc1
   RNSVG: 8ef4c60d9378eab6996a3f006dfb5784e6dab302
@@ -1039,4 +1039,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 543e2b50cb719b002eca725e63b881ca716979e9
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.12.0

--- a/fabricexample/src/KeyboardExample.tsx
+++ b/fabricexample/src/KeyboardExample.tsx
@@ -29,7 +29,7 @@ const Page = ({ title, description, onPress, buttonTitle }: PageProps) => {
     <>
       <Text style={styles.sectionTitle}>{title}</Text>
       <Text style={styles.sectionDescription}>{description}</Text>
-      <TextInput style={styles.textInput} />
+      <TextInput testID="text-input" style={styles.textInput} />
       <Button onPress={onPress} title={buttonTitle} />
     </>
   );

--- a/fabricexample/src/component/NavigationPanel/LogsPanel.tsx
+++ b/fabricexample/src/component/NavigationPanel/LogsPanel.tsx
@@ -8,7 +8,6 @@ export function LogsPanel({ logs }: LogsPanelProps) {
   return (
     <FlatList
       style={styles.container}
-      keyExtractor={({ timestamp }) => `${timestamp.getTime()}`}
       data={logs}
       renderItem={({ item }) => (
         //@ts-ignore

--- a/fabricexample/src/component/NavigationPanel/NavigationPanel.tsx
+++ b/fabricexample/src/component/NavigationPanel/NavigationPanel.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
-import { StyleSheet, Text, View } from 'react-native';
-import { TouchableOpacity } from 'react-native-gesture-handler';
+import { StyleSheet, Text, View, TouchableOpacity } from 'react-native';
 import { ControlsPanel } from './ControlPanel';
 import { LogsPanel } from './LogsPanel';
 import type { NavigationPanelProps } from './types';
@@ -97,37 +96,5 @@ const styles = StyleSheet.create({
   },
   toggleVisibilityTextActive: {
     color: '#000',
-  },
-  buttons: {
-    flexDirection: 'row',
-    backgroundColor: 'black',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-  },
-  hiddenContainer: {
-    height: 0,
-    overflow: 'hidden',
-  },
-  buttonAdjustment: {
-    flex: 1,
-  },
-  progress: {
-    flexDirection: 'row',
-    height: 40,
-    backgroundColor: 'black',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-  },
-  buttonText: {
-    color: 'white',
-    paddingHorizontal: 20,
-  },
-  scrollState: {
-    flex: 1,
-    justifyContent: 'flex-end',
-  },
-  scrollStateText: {
-    color: '#99d1b7',
-    textAlign: 'center',
   },
 });

--- a/fabricexample/src/hook/useNavigationPanel.ts
+++ b/fabricexample/src/hook/useNavigationPanel.ts
@@ -54,10 +54,14 @@ export function useNavigationPanel(
     () => setPages((prevPages) => [...prevPages, createPage(prevPages.length)]),
     []
   );
-  const removePage = useCallback(
-    () => setPages((prevPages) => prevPages.slice(0, prevPages.length - 1)),
-    []
-  );
+  const removePage = useCallback(() => {
+    setPages((prevPages) => {
+      if (prevPages.length === 1) {
+        return prevPages;
+      }
+      return prevPages.slice(0, prevPages.length - 1);
+    });
+  }, []);
   const toggleAnimation = useCallback(
     () => setIsAnimated((animated) => !animated),
     []


### PR DESCRIPTION
# Summary

- Fix duplicated key in logs panel
- Use `TouchableOpacity` from RN instead of react-native-gesture-handler, on Android it did not work. It was caused by missing setup from these docs: https://docs.swmansion.com/react-native-gesture-handler/docs/installation#usage-with-modals-on-android . Based on the info from @troZee we don't need it, so I changed it to one provided by RN.
- Add missing testId to simplify tests written in Maestro
- Prevent removing last page

## Test Plan

1. Validate that events generated in logs panel do not trigger duplicated key warning.
2. Verify that control tab works correctly on Android.
3. Verify that removing last page does not remove page if only 1 is present

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
