### PR TITLE
feat: add button to quickly switch layout direction

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -10,6 +10,8 @@ import {
   TouchableOpacity,
   Button,
   Alert,
+  I18nManager,
+  DevSettings,
 } from 'react-native';
 import { NavigationContainer, useNavigation } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
@@ -119,6 +121,16 @@ export function Navigation() {
                   }
                   title={mode === 'js' ? 'JS' : 'NATIVE'}
                   color="orange"
+                />
+              ),
+              headerLeft: () => (
+                <Button
+                  title={I18nManager.getConstants().isRTL ? 'RTL' : 'LTR'}
+                  color="orange"
+                  onPress={() => {
+                    I18nManager.forceRTL(!I18nManager.getConstants().isRTL);
+                    DevSettings.reload();
+                  }}
                 />
               ),
             }}

--- a/fabricexample/src/App.tsx
+++ b/fabricexample/src/App.tsx
@@ -10,6 +10,8 @@ import {
   TouchableOpacity,
   Button,
   Alert,
+  I18nManager,
+  DevSettings,
 } from 'react-native';
 import { NavigationContainer, useNavigation } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
@@ -117,6 +119,16 @@ export function Navigation() {
                 }
                 title={mode === 'js' ? 'JS' : 'NATIVE'}
                 color="orange"
+              />
+            ),
+            headerLeft: () => (
+              <Button
+                title={I18nManager.getConstants().isRTL ? 'RTL' : 'LTR'}
+                color="orange"
+                onPress={() => {
+                  I18nManager.forceRTL(!I18nManager.getConstants().isRTL);
+                  DevSettings.reload();
+                }}
               />
             ),
           }}


### PR DESCRIPTION
# Summary

Goal of this PR is to make it easier to test RTL / LTR directions for provided examples.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

<img src="https://user-images.githubusercontent.com/52801365/230205463-0a35c193-c12c-43c6-ae11-31f928f5e82b.png" height="600" />


Launch example app switch LTR to RTL.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
