### PR TITLE
Stop debouncing onPageSelected event on Android

### DIFF
--- a/android/src/main/java/com/reactnativepagerview/event/PageSelectedEvent.kt
+++ b/android/src/main/java/com/reactnativepagerview/event/PageSelectedEvent.kt
@@ -17,6 +17,10 @@ class PageSelectedEvent(viewTag: Int, private val mPosition: Int) : Event<PageSe
         return EVENT_NAME
     }
 
+    override fun canCoalesce(): Boolean {
+      return false
+    }
+
     override fun dispatch(rctEventEmitter: RCTEventEmitter) {
         rctEventEmitter.receiveEvent(viewTag, eventName, serializeEventData())
     }


### PR DESCRIPTION
# Summary

The change unifies the behaviour of the onPageSelected event on Android to work in the same way as on iOS. 

On iOS, coalescing key is always new for each onPageSelected event:
<img width="970" alt="Zrzut ekranu 2023-04-12 o 16 18 11" src="https://user-images.githubusercontent.com/16975059/231486498-03c3f3de-ffcc-4a30-adaf-dcb56f7d062c.png">


Before this change, a quick swipe on Android caused some events to be missed, resulting in JS not being informed of each page change.

Negative impact: may slightly degrade performance on android (depending on how the code is written)

## Test Plan

Start swiping fast. Check the incoming "position" in onPageSelected event (it should be incrementing, without holes).

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
