### PR TITLE
feat: registration compat for 0.68/0.69

### DIFF
--- a/android/Android.mk
+++ b/android/Android.mk
@@ -1,0 +1,45 @@
+THIS_DIR := $(call my-dir)
+
+include $(REACT_ANDROID_DIR)/Android-prebuilt.mk
+
+include ${GENERATED_SRC_DIR}/codegen/jni/Android.mk
+
+include $(CLEAR_VARS)
+
+LOCAL_PATH := $(THIS_DIR)
+
+# Define the library name here.
+LOCAL_MODULE := ${CODEGEN_MODULE_NAME}_registration
+
+LOCAL_SRC_FILES := $(wildcard $(LOCAL_PATH)/*.cpp)
+
+LOCAL_SHARED_LIBRARIES := \
+  libfabricjni \
+  libfbjni \
+  libglog \
+  libjsi \
+  libreact_codegen_rncore \
+  libreact_codegen_${CODEGEN_MODULE_NAME} \
+  libreact_debug \
+  libreact_nativemodule_core \
+  libreact_render_componentregistry \
+  libreact_render_core \
+  libreact_render_debug \
+  libreact_render_graphics \
+  librrc_view \
+  libruntimeexecutor \
+  libturbomodulejsijni \
+  libyoga
+
+ifneq ($(filter $(call modules-get-list),folly_runtime),)
+  LOCAL_SHARED_LIBRARIES += libfolly_runtime # since react-native@0.69
+else
+  LOCAL_SHARED_LIBRARIES += libfolly_futures libfolly_json # react-native@0.68
+endif
+
+LOCAL_CFLAGS := \
+  -DLOG_TAG=\"ReactNative\" \
+  -DCODEGEN_COMPONENT_DESCRIPTOR_H="<react/renderer/components/${CODEGEN_MODULE_NAME}/ComponentDescriptors.h>"
+LOCAL_CFLAGS += -fexceptions -frtti -std=c++17 -Wall
+
+include $(BUILD_SHARED_LIBRARY)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,6 +34,30 @@ def getExtOrIntegerDefault(name) {
   return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties['PagerView_' + name]).toInteger()
 }
 
+import groovy.json.JsonSlurper
+
+// https://github.com/callstack/react-native-builder-bob/discussions/359
+def registrationCompat = {
+  def reactAndroidProject = rootProject.allprojects.find { it.name == 'ReactAndroid' }
+  if (reactAndroidProject == null) return false
+
+  def reactNativeManifest = file("${reactAndroidProject.projectDir}/../package.json")
+  def reactNativeVersion = new JsonSlurper().parseText(reactNativeManifest.text).version as String
+  // Fabric was introduced at react-native@0.68, full CMake support were introduced at react-native@0.71
+  // Use Android.mk for compatibility with react-native@0.68/0.69
+  reactNativeVersion.matches('(0.68.*|0.69.*)')
+}()
+
+def codegenViewLibraryName = "RNCViewPager"
+def codegenViewModuleName = {
+  // Autolink for Fabric uses codegenConfig.name in package.json since react-native@0.70
+  // Use codegenViewLibraryName for compatibility with react-native@0.68/0.69
+  def libraryManifestJson = new JsonSlurper().parseText(file("$projectDir/../package.json").text)
+  registrationCompat ? codegenViewLibraryName : libraryManifestJson.codegenConfig.name
+}()
+
+def appProject = rootProject.allprojects.find { it.plugins.hasPlugin('com.android.application') }
+
 android {
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
 
@@ -41,7 +65,38 @@ android {
     minSdkVersion getExtOrIntegerDefault('minSdkVersion')
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
     buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
+
+    buildConfigField "String", "CODEGEN_MODULE_REGISTRATION", (isNewArchitectureEnabled() && registrationCompat ? "\"${codegenViewModuleName}_registration\"" : "null")
+
+    if (isNewArchitectureEnabled() && registrationCompat) {
+      def reactAndroidProject = project(':ReactAndroid')
+      externalNativeBuild {
+        ndkBuild {
+          arguments "APP_PLATFORM=android-21",
+                    "APP_STL=c++_shared",
+                    "NDK_TOOLCHAIN_VERSION=clang",
+                    "GENERATED_SRC_DIR=$buildDir/generated/source", // for react_codegen_* in this library's codegen/jni
+                    "PROJECT_BUILD_DIR=${appProject.buildDir}", // for REACT_NDK_EXPORT_DIR in ReactAndroid's Android-prebuilt.mk
+                    "REACT_ANDROID_DIR=${reactAndroidProject.projectDir}",
+                    "REACT_ANDROID_BUILD_DIR=${reactAndroidProject.buildDir}",
+                    "CODEGEN_MODULE_NAME=$codegenViewModuleName"
+          cFlags "-Wall", "-Werror", "-fexceptions", "-frtti", "-DWITH_INSPECTOR=1"
+          cppFlags "-std=c++17"
+          targets "${codegenViewModuleName}_registration"
+        }
+      }
+    }
   }
+
+  if (isNewArchitectureEnabled() && registrationCompat) {
+    // We configure the NDK build only if you decide to opt-in for the New Architecture.
+    externalNativeBuild {
+      ndkBuild {
+        path "Android.mk"
+      }
+    }
+  }
+
   buildTypes {
     release {
       minifyEnabled false
@@ -152,7 +207,7 @@ dependencies {
 if (isNewArchitectureEnabled()) {
   react {
     jsRootDir = file("../src")
-    libraryName = "RNCViewPager"
+    libraryName = codegenViewLibraryName
     codegenJavaPackageName = "com.reactnativepagerview"
   }
 }

--- a/android/registration.cpp
+++ b/android/registration.cpp
@@ -1,0 +1,18 @@
+#include <CoreComponentsRegistry.h>
+#include CODEGEN_COMPONENT_DESCRIPTOR_H
+
+namespace facebook {
+namespace react {
+
+void registerProviders() {
+    auto providerRegistry = CoreComponentsRegistry::sharedProviderRegistry();
+    providerRegistry->add(concreteComponentDescriptorProvider<RNCViewPagerComponentDescriptor>());
+}
+
+}
+}
+
+JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *) {
+    facebook::react::registerProviders();
+    return JNI_VERSION_1_6;
+}

--- a/android/src/fabric/java/com/reactnativepagerview/PagerViewViewManager.kt
+++ b/android/src/fabric/java/com/reactnativepagerview/PagerViewViewManager.kt
@@ -13,6 +13,7 @@ import com.facebook.react.uimanager.*
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.viewmanagers.RNCViewPagerManagerDelegate
 import com.facebook.react.viewmanagers.RNCViewPagerManagerInterface
+import com.facebook.soloader.SoLoader
 import com.reactnativepagerview.event.PageScrollEvent
 import com.reactnativepagerview.event.PageScrollStateChangedEvent
 import com.reactnativepagerview.event.PageSelectedEvent
@@ -20,6 +21,14 @@ import com.reactnativepagerview.event.PageSelectedEvent
 
 @ReactModule(name = PagerViewViewManagerImpl.NAME)
 class PagerViewViewManager : ViewGroupManager<NestedScrollableHost>(), RNCViewPagerManagerInterface<NestedScrollableHost> {
+    companion object {
+        init {
+            if (BuildConfig.CODEGEN_MODULE_REGISTRATION != null) {
+                SoLoader.loadLibrary(BuildConfig.CODEGEN_MODULE_REGISTRATION)
+            }
+        }
+    }
+
     private val mDelegate: ViewManagerDelegate<NestedScrollableHost> = RNCViewPagerManagerDelegate(this)
 
     override fun getDelegate() = mDelegate


### PR DESCRIPTION
# Summary

Support for Fabric on 0.68/0.69 requires manual registration inside custom `RNScreensComponentsRegistry`, according to [Introducing Fabric to react-native-screens](https://blog.swmansion.com/introducing-fabric-to-react-native-screens-fd17bf18858e), especially [Android base changes](https://github.com/software-mansion/react-native-screens/pull/1263)

This PR backports `react-native-pager-view` to 0.68/0.69 as https://github.com/callstack/react-native-builder-bob/pull/360

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Tested on `fabric-compat` example: https://github.com/Sunbreak/react-native-pager-view/tree/compat-example

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
