### PR TITLE
fix: return when user navigates to the same page

### DIFF
--- a/ios/Fabric/RNCPagerViewComponentView.mm
+++ b/ios/Fabric/RNCPagerViewComponentView.mm
@@ -192,6 +192,10 @@ using namespace facebook::react;
 - (void)goTo:(NSInteger)index animated:(BOOL)animated {
     NSInteger numberOfPages = _nativeChildrenViewControllers.count;
     
+    if (index == _currentIndex) {
+        return;
+    }
+    
     [self disableSwipe];
     
     _destinationIndex = index;

--- a/ios/ReactNativePageView.m
+++ b/ios/ReactNativePageView.m
@@ -243,6 +243,10 @@
 - (void)goTo:(NSInteger)index animated:(BOOL)animated {
     NSInteger numberOfPages = self.reactSubviews.count;
     
+    if (index == _currentIndex) {
+        return;
+    }
+    
     [self disableSwipe];
     
     _destinationIndex = index;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

Sometimes when navigating between pages (using TabBar) view state was getting out of sync, to be specific the `view.animating` was being set to true when it wasn't animating. This was happening when user was pressing multiple times on the same item. 

Therefore, this check was met: 

```objc
if (!animated || !view.animating) {
    [view goTo:index.integerValue animated:animated];
}
```
Which caused pager view to be stuck on the same page. This check prevents this from happening. Reported here: https://github.com/react-navigation/react-navigation/issues/10425


## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Go to TabView example and click on the same tab bar item multiple times. Check that it stops on the early return.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [x] I updated the typed files (TS and Flow)
