### PR TITLE
fix: rename setScrollEnabled to setScrollEnabledImperatively on old arch

### DIFF
--- a/ios/ReactViewPagerManager.m
+++ b/ios/ReactViewPagerManager.m
@@ -63,7 +63,7 @@ RCT_EXPORT_METHOD(setPageWithoutAnimation
     [self goToPage:reactTag index:index animated:false];
 }
 
-RCT_EXPORT_METHOD(setScrollEnabled
+RCT_EXPORT_METHOD(setScrollEnabledImperatively
                   : (nonnull NSNumber *)reactTag enabled
                   : (nonnull NSNumber *)enabled) {
     BOOL isEnabled = [enabled boolValue];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Rename `setScrollEnabled` to `setScrollEnabledImperatively` to fix setting scroll enabled by calling a method on ViewPager ref. 

Currently when calling `ref.current?.setScrollEnabled(false);` we get this error message: 


 <img src="https://github.com/callstack/react-native-pager-view/assets/52801365/21896507-fd3e-434a-aac4-50221d106b7f" alt="alt text" width="300">


This was left over from the new arch migration. Fixes: #750

Currently when 

## Test Plan
Render this button in basic example and check if it works. 
```jsx
<Button
                  title="Set scroll enabled imperatively"
                  onPress={() => {
                    ref.current?.setScrollEnabled(false);
                  }}
                />
```

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
