### PR TITLE
fix(android): remove the redundant `PageSelectedEvent` dispatch causing an ANR on RN 0.72

### DIFF
--- a/android/src/fabric/java/com/reactnativepagerview/PagerViewViewManager.kt
+++ b/android/src/fabric/java/com/reactnativepagerview/PagerViewViewManager.kt
@@ -183,10 +183,6 @@ class PagerViewViewManager : ViewGroupManager<NestedScrollableHost>(), RNCViewPa
         val canScroll = childCount != null && childCount > 0 && selectedPage >= 0 && selectedPage < childCount
         if (canScroll) {
             PagerViewViewManagerImpl.setCurrentItem(view, selectedPage, scrollWithAnimation)
-            val reactContext = view.context as ReactContext
-            UIManagerHelper.getEventDispatcherForReactTag(reactContext, view.id)?.dispatchEvent(
-                    PageSelectedEvent(view.id, selectedPage)
-            )
         }
     }
 

--- a/android/src/paper/java/com/reactnativepagerview/PagerViewViewManager.kt
+++ b/android/src/paper/java/com/reactnativepagerview/PagerViewViewManager.kt
@@ -146,7 +146,6 @@ class PagerViewViewManager : ViewGroupManager<NestedScrollableHost>() {
                 if (canScroll) {
                     val scrollWithAnimation = commandId == COMMAND_SET_PAGE
                     PagerViewViewManagerImpl.setCurrentItem(view, pageIndex, scrollWithAnimation)
-                    eventDispatcher.dispatchEvent(PageSelectedEvent(root.id, pageIndex))
                 }
             }
             COMMAND_SET_SCROLL_ENABLED -> {


### PR DESCRIPTION
This PR removes a redundant `PageSelectedEvent` dispatch causing an ANR on RN 0.72.

Closes #752 

# Summary

In the following function:

https://github.com/callstack/react-native-pager-view/blob/2946c1c33df6cacc8f9f77220bb879b39bb75ace/android/src/fabric/java/com/reactnativepagerview/PagerViewViewManager.kt#L167-L182

On the new architecture, using RN 0.72, the event in L178-L180 is dispatched with an incorrect `view.id` of `-1` which apparently trips React Native up causing a silent error leading to an ANR.

One way to fix it is to adjust the ID used with this dispatch, e.g. by replacing `view.id` with `root.id`, which contains the correct ID value, which solves the issue.

However, the `PagerViewViewManagerImpl.setCurrentItem(...)` call in L176 also (implicitly) triggers a `PageSelectedEvent` dispatch, via the `onPageSelected` callback:

https://github.com/callstack/react-native-pager-view/blob/2946c1c33df6cacc8f9f77220bb879b39bb75ace/android/src/fabric/java/com/reactnativepagerview/PagerViewViewManager.kt#L54-L59

Which makes the first dispatch redundant. Hence, this PR removes this dispatch on both architectures (consulted with @troZee).


## Test Plan

Test the example app on both architectures and confirm there's no ANR.


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
