### PR TITLE
fix(next/iOS): fix blinking during initial render when initialPage !=0 in non-fabric version

### DIFF
--- a/ios/RNCPagerView.m
+++ b/ios/RNCPagerView.m
@@ -17,6 +17,7 @@
 
 @property(nonatomic, strong) RNCPagerScrollView *scrollView;
 @property(nonatomic, strong) UIView *containerView;
+@property(nonatomic, assign) BOOL scrolledToInitialPage;
 
 - (void)goTo:(NSInteger)index animated:(BOOL)animated;
 - (void)shouldScroll:(BOOL)scrollEnabled;
@@ -46,6 +47,15 @@
         [self.scrollView.panGestureRecognizer requireGestureRecognizerToFail:self.reactViewController.navigationController.interactivePopGestureRecognizer];
     }
 }
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    if (!_scrolledToInitialPage) {
+        _scrolledToInitialPage = YES;
+        [self goTo:self.initialPage animated:false];
+    }
+}
+
 
 - (void)didUpdateReactSubviews {
     [self updateContentSizeIfNeeded];
@@ -118,10 +128,6 @@
     if (!CGSizeEqualToSize(_scrollView.contentSize, contentSize)){
         _scrollView.contentSize = [self isHorizontal] ? CGSizeMake(contentSize.width, 0) : CGSizeMake(0, contentSize.height);
         _containerView.frame = CGRectMake(0, 0, contentSize.width, contentSize.height);
-        
-        if (self.initialPage != 0) {
-            [self goTo:self.initialPage animated:false];
-        }
     }
 }
 


### PR DESCRIPTION
# Summary

Fabric has a trick with -1. Unfortunately here we can't use it. The only place that allows a valid goTo from the initial page is layoutSubviews.

## Test Plan

1. render pager with initialPage bigger than zero and many pages inside
2. pager is blinking (for a brief moment)

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
