### PR TITLE
feat: add support for visionOS

### DIFF
--- a/ios/Fabric/RNCPagerViewComponentView.mm
+++ b/ios/Fabric/RNCPagerViewComponentView.mm
@@ -122,6 +122,7 @@ using namespace facebook::react;
 }
 
 - (void)shouldDismissKeyboard:(RNCViewPagerKeyboardDismissMode)dismissKeyboard {
+#if !TARGET_OS_VISION
     UIScrollViewKeyboardDismissMode dismissKeyboardMode = UIScrollViewKeyboardDismissModeNone;
     switch (dismissKeyboard) {
         case RNCViewPagerKeyboardDismissMode::None:
@@ -132,6 +133,7 @@ using namespace facebook::react;
             break;
     }
     scrollView.keyboardDismissMode = dismissKeyboardMode;
+#endif
 }
 
 

--- a/ios/ReactNativePageView.h
+++ b/ios/ReactNativePageView.h
@@ -15,7 +15,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic) NSInteger currentIndex;
 @property(nonatomic) NSInteger pageMargin;
 @property(nonatomic, readonly) BOOL scrollEnabled;
+#if !TARGET_OS_VISION
 @property(nonatomic, readonly) UIScrollViewKeyboardDismissMode dismissKeyboard;
+#endif
 @property(nonatomic) UIPageViewControllerNavigationOrientation orientation;
 @property(nonatomic, copy) RCTDirectEventBlock onPageSelected;
 @property(nonatomic, copy) RCTDirectEventBlock onPageScroll;

--- a/ios/ReactNativePageView.m
+++ b/ios/ReactNativePageView.m
@@ -41,7 +41,9 @@
         _destinationIndex = -1;
         _orientation = UIPageViewControllerNavigationOrientationHorizontal;
         _currentIndex = 0;
+#if !TARGET_OS_VISION
         _dismissKeyboard = UIScrollViewKeyboardDismissModeNone;
+#endif
         _coalescingKey = 0;
         _eventDispatcher = eventDispatcher;
         _cachedControllers = [NSHashTable hashTableWithOptions:NSHashTableStrongMemory];
@@ -102,7 +104,9 @@
     for (UIView *subview in pageViewController.view.subviews) {
         if([subview isKindOfClass:UIScrollView.class]){
             ((UIScrollView *)subview).delegate = self;
+#if !TARGET_OS_VISION
             ((UIScrollView *)subview).keyboardDismissMode = _dismissKeyboard;
+#endif
             ((UIScrollView *)subview).delaysContentTouches = YES;
             self.scrollView = (UIScrollView *)subview;
         }
@@ -128,9 +132,11 @@
 }
 
 - (void)shouldDismissKeyboard:(NSString *)dismissKeyboard {
+#if !TARGET_OS_VISION
     _dismissKeyboard = [dismissKeyboard  isEqual: @"on-drag"] ?
     UIScrollViewKeyboardDismissModeOnDrag : UIScrollViewKeyboardDismissModeNone;
     self.scrollView.keyboardDismissMode = _dismissKeyboard;
+#endif
 }
 
 - (void)setupInitialController {

--- a/react-native-pager-view.podspec
+++ b/react-native-pager-view.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => "10.0" }
+  s.platforms    = { :ios => "10.0", :visionos => "1.0" }
   s.source       = { :git => "https://github.com/callstack/react-native-pager-view.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm}"


### PR DESCRIPTION
# Summary

This PR adds support for `visionOS`. Using compiler conditionals to prevent compiling unavailable APIs.


https://github.com/callstack/react-native-pager-view/assets/52801365/fa12de6f-d3c3-47b4-9727-9f3fc068bc26



## Test Plan

1. Init visionOS app: `npx @callstack/react-native-visionos init App`
2. Add pager-view 
3. Check if everything works

### What's required for testing (prerequisites)?

Xcode 15.1 Beta


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
