### PR TITLE
feat: added sensitivity controller to android

### DIFF
--- a/android/src/main/java/com/reactnativepagerview/PagerViewViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativepagerview/PagerViewViewManagerImpl.kt
@@ -3,6 +3,7 @@ package com.reactnativepagerview
 import android.view.View
 import androidx.viewpager2.widget.ViewPager2
 import com.facebook.react.uimanager.PixelUtil
+import androidx.recyclerview.widget.RecyclerView
 
 object PagerViewViewManagerImpl {
     const val NAME = "RNCViewPager"
@@ -18,6 +19,16 @@ object PagerViewViewManagerImpl {
     fun setCurrentItem(view: ViewPager2, selectedTab: Int, scrollSmooth: Boolean) {
         refreshViewChildrenLayout(view)
         view.setCurrentItem(selectedTab, scrollSmooth)
+    }
+
+    fun ViewPager2.reduceDragSensitivity(value: Int) {
+        val recyclerViewField = ViewPager2::class.java.getDeclaredField("mRecyclerView")
+        recyclerViewField.isAccessible = true
+       val recyclerView = recyclerViewField.get(this) as RecyclerView
+       val touchSlopField = RecyclerView::class.java.getDeclaredField("mTouchSlop")
+       touchSlopField.isAccessible = true
+       val touchSlop = touchSlopField.get(recyclerView) as Int
+       touchSlopField.set(recyclerView, touchSlop*value)
     }
 
     fun addView(host: NestedScrollableHost, child: View?, index: Int) {

--- a/android/src/paper/java/com/reactnativepagerview/PagerViewViewManager.kt
+++ b/android/src/paper/java/com/reactnativepagerview/PagerViewViewManager.kt
@@ -13,6 +13,7 @@ import com.facebook.react.uimanager.UIManagerModule
 import com.facebook.react.uimanager.ViewGroupManager
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.uimanager.events.EventDispatcher
+import com.reactnativepagerview.PagerViewViewManagerImpl.reduceDragSensitivity
 import com.reactnativepagerview.event.PageScrollEvent
 import com.reactnativepagerview.event.PageScrollStateChangedEvent
 import com.reactnativepagerview.event.PageSelectedEvent
@@ -124,6 +125,12 @@ class PagerViewViewManager : ViewGroupManager<NestedScrollableHost>() {
     fun setLayoutDirection(host: NestedScrollableHost, value: String) {
         PagerViewViewManagerImpl.setLayoutDirection(host, value)
     }
+
+    @ReactProp(name = "scrollSensitivity", defaultInt = 2)
+   fun setScrollSensitivity(host: NestedScrollableHost, value: Int) {
+       val view = PagerViewViewManagerImpl.getViewPager(host)
+       view.reduceDragSensitivity(value)
+   }
 
     override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Map<String, String>> {
         return MapBuilder.of(

--- a/src/PagerViewNativeComponent.ts
+++ b/src/PagerViewNativeComponent.ts
@@ -22,6 +22,8 @@ export type OnPageScrollStateChangedEventData = Readonly<{
   pageScrollState: 'idle' | 'dragging' | 'settling';
 }>;
 
+export type ScrollSensitivity = 2 | 3 | 4 | 5 | 6 | 7 | 8;
+
 export interface NativeProps extends ViewProps {
   scrollEnabled?: WithDefault<boolean, true>;
   layoutDirection?: WithDefault<'ltr' | 'rtl', 'ltr'>;
@@ -35,6 +37,7 @@ export interface NativeProps extends ViewProps {
   onPageScroll?: DirectEventHandler<OnPageScrollEventData>;
   onPageSelected?: DirectEventHandler<OnPageSelectedEventData>;
   onPageScrollStateChanged?: DirectEventHandler<OnPageScrollStateChangedEventData>;
+  scrollSensitivity?: ScrollSensitivity;
 }
 
 type PagerViewViewType = HostComponent<NativeProps>;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

This pull request allows users to toggle the sensitivity on android.  It is particularly useful for pagerview's that contain scrollable webviews.  


## Test Plan

Make sure the prop filters through the JS to reduceDragSensitivity kotlin function and is set correctly.  Make sure the app visibly scrolls with less sensitivity as the number increasers.

### What's required for testing (prerequisites)? 
Just be able to run the app in android studio

### What are the steps to reproduce (after prerequisites)?

Go to BasicPagerViewExample and add the prop
ScrollSensitivity={8}
in Android studio put a stop on 
android/src/main/java/com/reactnativepagerview/PagerViewViewManagerImpl.kt on line 25.

Run the basic example and when the stop fires check that the prop is correctly set at 8.

You can also toggle the number and notice the reduced sensitivity on higher numbers.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅    |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
