### PR TITLE
fix(ios): fix freezing when navigating to same index

### DIFF
--- a/ios/RNCPagerView.m
+++ b/ios/RNCPagerView.m
@@ -126,6 +126,10 @@
 }
 
 - (void)goTo:(NSInteger)index animated:(BOOL)animated {
+    if ([self getCurrentPage] == index) {
+        return;
+    }
+    
     CGPoint targetOffset = [self isHorizontal] ? CGPointMake(_scrollView.frame.size.width * index, 0) : CGPointMake(0, _scrollView.frame.size.height * index);
     
     if (animated) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

This PR fixes issue causing `PagerView` to freeze after calling `goTo` to same index (Paper arch only)

Fixes #803 

## Test Plan

1. Open any example with tab
2. Tap on currently selected tab
3. Pager should be scrollable

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
