### PR TITLE
fix(android): index out of bounds crash

### DIFF
--- a/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt
+++ b/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt
@@ -63,7 +63,9 @@ class ViewPagerAdapter() : Adapter<ViewPagerViewHolder>() {
   }
 
   fun removeChildAt(index: Int) {
-    childrenViews.removeAt(index)
-    notifyItemRemoved(index)
+    if (index >= 0 && index < childrenViews.size) { 
+      childrenViews.removeAt(index)
+      notifyItemRemoved(index)
+    }
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

We are using "react-native-tab-view" in Dream11 App. We were not able to reproduce the crash, But we are seeing crash instance in firebase. We can see that partial [fix](https://github.com/callstack/react-native-pager-view/blob/d0b77b33140e5492cfd6438b55f80bdf957dd9c5/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt#L48) of this is already merged in **react-native-tab-view**.  This fix works only if **removeChildAt** of **ViewPagerAdapter** gets called from **removeChild** of **ViewPagerAdapter**.  The existing fix won't work [here](https://github.com/callstack/react-native-pager-view/blob/d0b77b33140e5492cfd6438b55f80bdf957dd9c5/android/src/main/java/com/reactnativepagerview/PagerViewViewManagerImpl.kt#L72). This PR takes care of boundary conditions of childrenViews array. 
Here are the attached logs/stack traces. 
```
Fatal Exception: java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0
       at jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64)
       at jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70)
       at jdk.internal.util.Preconditions.checkIndex(Preconditions.java:266)
       at java.util.Objects.checkIndex(Objects.java:359)
       at java.util.ArrayList.remove(ArrayList.java:511)
       at o.requestAccessibilityFocus.Instrument(SourceFile:57)
       at o.requestAccessibilityFocus.values(SourceFile:47)
       at com.reactnativepagerview.PagerViewViewManager.removeView(SourceFile:110)
       at com.reactnativepagerview.PagerViewViewManager.removeView(SourceFile:21)
       at com.swmansion.reanimated.layoutReanimation.ReanimatedNativeHierarchyManager.lambda$manageChildren$0(SourceFile:375)
       at com.swmansion.reanimated.layoutReanimation.ReanimatedNativeHierarchyManager$$ExternalSyntheticLambda0.run(:8)

```       
```
Fatal Exception: java.lang.IndexOutOfBoundsException: Index -1 out of bounds for length 3
       at jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64)
       at jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70)
       at jdk.internal.util.Preconditions.checkIndex(Preconditions.java:266)
       at java.util.Objects.checkIndex(Objects.java:359)
       at java.util.ArrayList.remove(ArrayList.java:511)
       at o.requestAccessibilityFocus.Instrument(SourceFile:57)
       at o.requestAccessibilityFocus.values(SourceFile:47)
       at com.reactnativepagerview.PagerViewViewManager.removeView(SourceFile:110)
       at com.reactnativepagerview.PagerViewViewManager.removeView(SourceFile:21)
       at com.swmansion.reanimated.layoutReanimation.ReanimatedNativeHierarchyManager.lambda$manageChildren$0(SourceFile:375)
       at com.swmansion.reanimated.layoutReanimation.ReanimatedNativeHierarchyManager$$ExternalSyntheticLambda0.run(:8)
       at com.swmansion.reanimated.layoutReanimation.ReanimatedNativeHierarchyManager.dropView(SourceFile:414)
       at com.facebook.react.uimanager.NativeViewHierarchyManager$1.onAnimationEnd(SourceFile:491)

``` 

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅    |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ✅ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
