### PR TITLE
[Fix] Make sure that RCTEventEmitter is registered before emitting the first event

### DIFF
--- a/src/PagerView.tsx
+++ b/src/PagerView.tsx
@@ -14,6 +14,17 @@ import PagerViewView, {
   Commands as PagerViewCommands,
 } from './PagerViewNativeComponent';
 
+// The Fabric component for PagerView uses a work around present also in ScrollView:
+// https://github.com/callstack/react-native-pager-view/blob/master/ios/Fabric/RNCPagerViewComponentView.mm#L362-L368
+// That workaround works only if we add these lines in to make sure that the RCTEventEmitter is registered properly
+// in the JS callable modules.
+// NOTE: This is a workaround as we would like to get rid of these lines below. But for the time being, as the cut date for
+// 0.74 approaches, we need to keep these lines.
+// As soon as we figure out how to move forward, we will provide guidance and/or submit a PR to fix this.
+if (Platform.OS === 'ios') {
+  require('react-native/Libraries/Renderer/shims/ReactNative'); // Force side effects to prevent T55744311
+}
+
 /**
  * Container that allows to flip left and right between child views. Each
  * child view of the `PagerView` will be treated as a separate page


### PR DESCRIPTION
# Summary

React Native pager view emits an error when used with Nightlies on the New Architecture with and without the Bridge.

The reason is that Pager View copied a [work around we also have in ScrollView](https://github.com/callstack/react-native-pager-view/blob/master/ios/Fabric/RNCPagerViewComponentView.mm#L362-L368) to allow apps to implement complex animations, like parallax animations, but it forgot to add the JS side of it, that makes the workaround effective.
The JS part is to make sure that `RCTEventEmitter` is properly registered as CallableModule in the JS side.

This PR adds that bit, copying what ScrollView does.

_For context, we are not happy with this workaround. We still have to figure out properly how to fix it and, as soon as we know, we are going to provide guidance and/or submit a new PR to fix this for good, depending on how much time we will have_

## Test Plan

Tested locally using:
* `react-native@Nightly 0.74.0-nightly-20240208-b796cda38`
* `react-native-pager-view@6.2.3`

| Before | After |
| --- | --- |
| ![Simulator Screen Recording - iPhone 15 - 2024-02-13 at 18 00 38](https://github.com/callstack/react-native-pager-view/assets/11162307/318349ea-0ceb-4157-8afc-9295131e43be) | ![Simulator Screen Recording - iPhone 15 - 2024-02-13 at 17 59 10](https://github.com/callstack/react-native-pager-view/assets/11162307/711b4d51-55c0-4bf0-9b6a-e278d63a5b9a) |


### What's required for testing (prerequisites)?
Being able to create and run a react native app.

### What are the steps to reproduce (after prerequisites)?
```
npx react-native@nightly init AppName --skip-install --version nightly
cd AppName
yarn add react-native-pager-view
cd ios
bundle install
RCT_NEW_ARCH_ENABLED=1 bundle exec pod install
open NewApp.xcworkspace
cd ..
yarn start
```

then:
1. open the `App.tsx`
2. copy-and-paste the example in the react-native-pager-view github repo
3. try to swipe and observe the error.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    Not needed    |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] [Not Needed] I added the documentation in `README.md`
- [x] I updated the typed files (TS and Flow)
