### PR TITLE
Node.js 16 actions are deprecated.

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -20,18 +20,18 @@ jobs:
   android-build:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/install-dependencies
 
       - name: Pull dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./node_modules
           key: ${{ hashFiles('./package.json') }}
 
       - name: Cache example node modules
         id: cache-example-npm
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cached-example-npm-deps
         with:
@@ -42,13 +42,13 @@ jobs:
         if: steps.cache-example-npm.outputs.cache-hit != 'true'
         run: yarn bootstrap-no-pods --frozen-lockfile
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '11'
 
       - name: Gradle cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches
@@ -56,7 +56,7 @@ jobs:
           key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/buildSrc/**/*.kt') }}
 
       - name: AVD cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: avd-cache
         with:
           path: |
@@ -99,7 +99,7 @@ jobs:
 
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: E2E Report
           path: |
@@ -109,7 +109,7 @@ jobs:
             ~/.maestro/tests/**/*
 
       - name: Store tests result
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: e2e_android_report
           path: |

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -20,18 +20,18 @@ jobs:
   ios-build:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/install-dependencies
 
       - name: Pull dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./node_modules
           key: ${{ hashFiles('./package.json') }}
 
       - name: Cache example node modules
         id: cache-example-npm
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cached-example-npm-deps
         with:
@@ -45,7 +45,7 @@ jobs:
 
       - name: Cache Pods
         id: cache-pods
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cached-ios-pods-deps
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install dependencies
         uses: ./.github/actions/install-dependencies
 
@@ -28,17 +28,17 @@ jobs:
     needs: install-dependencies
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Pull dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./node_modules
           key: ${{ hashFiles('./package.json') }}
 
       - name: Pull example node modules
         id: cache-example-npm
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cached-example-npm-deps
         with:


### PR DESCRIPTION


# Summary

Please update the following actions to use Node.js 20: actions/checkout@v3, actions/cache@v3.

For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.


## Test Plan

just run workflows...
