### PR TITLE
fix(js): Native commands must be exported with the name 'Commands'

### DIFF
--- a/src/LEGACY_PagerViewNativeComponent/LEGACY_PagerViewNativeComponent.ts
+++ b/src/LEGACY_PagerViewNativeComponent/LEGACY_PagerViewNativeComponent.ts
@@ -67,7 +67,7 @@ interface NativeCommands {
   ) => void;
 }
 
-export const LEGACY_PagerViewNativeCommands: NativeCommands =
+export const Commands: NativeCommands =
   codegenNativeCommands<NativeCommands>({
     supportedCommands: [
       'setPage',

--- a/src/LEGACY_PagerViewNativeComponent/LEGACY_PagerViewNativeComponent.ts
+++ b/src/LEGACY_PagerViewNativeComponent/LEGACY_PagerViewNativeComponent.ts
@@ -67,14 +67,13 @@ interface NativeCommands {
   ) => void;
 }
 
-export const Commands: NativeCommands =
-  codegenNativeCommands<NativeCommands>({
-    supportedCommands: [
-      'setPage',
-      'setPageWithoutAnimation',
-      'setScrollEnabledImperatively',
-    ],
-  });
+export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
+  supportedCommands: [
+    'setPage',
+    'setPageWithoutAnimation',
+    'setScrollEnabledImperatively',
+  ],
+});
 
 export default codegenNativeComponent<NativeProps>(
   'LEGACY_RNCViewPager'

--- a/src/PagerView.tsx
+++ b/src/PagerView.tsx
@@ -9,7 +9,7 @@ import {
 } from './utils';
 
 import PagerViewNativeComponent, {
-  PagerViewNativeCommands,
+  Commands as PagerViewNativeCommands,
   OnPageScrollEventData,
   OnPageScrollStateChangedEventData,
   OnPageSelectedEventData,
@@ -17,7 +17,7 @@ import PagerViewNativeComponent, {
 } from './PagerViewNativeComponent/PagerViewNativeComponent';
 
 import LEGACY_PagerViewNativeComponent, {
-  LEGACY_PagerViewNativeCommands,
+  Commands as LEGACY_PagerViewNativeCommands,
 } from './LEGACY_PagerViewNativeComponent/LEGACY_PagerViewNativeComponent';
 
 // The Fabric component for PagerView uses a work around present also in ScrollView:

--- a/src/PagerViewNativeComponent/PagerViewNativeComponent.ts
+++ b/src/PagerViewNativeComponent/PagerViewNativeComponent.ts
@@ -56,7 +56,7 @@ export interface NativeCommands {
   ) => void;
 }
 
-export const PagerViewNativeCommands: NativeCommands =
+export const Commands: NativeCommands =
   codegenNativeCommands<NativeCommands>({
     supportedCommands: [
       'setPage',

--- a/src/PagerViewNativeComponent/PagerViewNativeComponent.ts
+++ b/src/PagerViewNativeComponent/PagerViewNativeComponent.ts
@@ -56,14 +56,13 @@ export interface NativeCommands {
   ) => void;
 }
 
-export const Commands: NativeCommands =
-  codegenNativeCommands<NativeCommands>({
-    supportedCommands: [
-      'setPage',
-      'setPageWithoutAnimation',
-      'setScrollEnabledImperatively',
-    ],
-  });
+export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
+  supportedCommands: [
+    'setPage',
+    'setPageWithoutAnimation',
+    'setScrollEnabledImperatively',
+  ],
+});
 
 export default codegenNativeComponent<NativeProps>(
   'RNCViewPager'


### PR DESCRIPTION
# Summary

This fixes a compatibility issue with React Native >0.73.

The export has to be named "Commands", otherwise it will cause this error:

```
error: node_modules/react-native-pager-view/src/PagerViewNativeComponent/PagerViewNativeComponent.ts:
 /[...]/node_modules/react-native-pager-view/src/PagerViewNativeComponent/PagerViewNativeComponent.ts:
Native commands must be exported with the name 'Commands'
```

## Test Plan

Only the export names are changed. No functional change.

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
