### PR TITLE
(#823) Export PagerView type

### DIFF
--- a/src/PagerView.tsx
+++ b/src/PagerView.tsx
@@ -233,3 +233,9 @@ export const PagerView = React.forwardRef<PagerViewInternal, PagerViewProps>(
     return <PagerViewInternal {...rest} useLegacy={!useNext} ref={ref} />;
   }
 );
+
+// React.forwardRef does not type returned component properly, thus breaking Ref<MyComponent> typing.
+// One way to overcome this is using separate typing for component "interface",
+// but that breaks backward compatibility in this case.
+// Approach of merging type is hacky, but produces a good typing for both ref attributes and component itself.
+export type PagerView = PagerViewInternal & typeof PagerView;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
Fixes https://github.com/callstack/react-native-pager-view/issues/823

React.forwardRef typing does not allow simple usage of component as a ref type. This PR brings backward compatibility of Ref<PagerView>.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

Test PagerView component, ref, props typing.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
