### PR TITLE
Make useNext optional

### DIFF
--- a/src/PagerView.tsx
+++ b/src/PagerView.tsx
@@ -225,7 +225,7 @@ class PagerViewInternal extends React.Component<NativeProps> {
 }
 
 // Temporary solution. It should be removed once all things get fixed
-type PagerViewProps = Omit<NativeProps, 'useLegacy'> & { useNext: boolean };
+type PagerViewProps = Omit<NativeProps, 'useLegacy'> & { useNext?: boolean };
 
 export const PagerView = React.forwardRef<PagerViewInternal, PagerViewProps>(
   (props, ref) => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

6.3.1+ versions now require the `useNext` prop as reported in #837. This marks it back as optional.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

n/a - type only.

### What are the steps to reproduce (after prerequisites)?

n/a - type only.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    n/a     |
| Android |    n/a     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [x] I updated the typed files (TS and Flow)
