### PR TITLE
Fix child argument types in `addView` methods

### DIFF
--- a/android/src/fabric/java/com/reactnativepagerview/PagerViewViewManager.kt
+++ b/android/src/fabric/java/com/reactnativepagerview/PagerViewViewManager.kt
@@ -88,7 +88,7 @@ class PagerViewViewManager : ViewGroupManager<NestedScrollableHost>(), RNCViewPa
         return host
     }
 
-    override fun addView(host: NestedScrollableHost, child: View?, index: Int) {
+    override fun addView(host: NestedScrollableHost, child: View, index: Int) {
         PagerViewViewManagerImpl.addView(host, child, index)
     }
 

--- a/android/src/paper/java/com/reactnativepagerview/PagerViewViewManager.kt
+++ b/android/src/paper/java/com/reactnativepagerview/PagerViewViewManager.kt
@@ -69,7 +69,7 @@ class PagerViewViewManager : ViewGroupManager<NestedScrollableHost>() {
         return host
     }
 
-    override fun addView(host: NestedScrollableHost, child: View?, index: Int) {
+    override fun addView(host: NestedScrollableHost, child: View, index: Int) {
         PagerViewViewManagerImpl.addView(host, child, index)
     }
 


### PR DESCRIPTION
# Summary

Fixes https://github.com/callstack/react-native-pager-view/issues/850 and https://github.com/callstack/react-native-pager-view/issues/856.
As stated in the first issue, there seem to be unneeded nullabilities in `child` arguments for Android PagerViewManager (both paper and fabric). Their existence makes the methods override nothing, which in turn crashes the build.

## Test Plan

Run on a fresh android app.

### What's required for testing (prerequisites)?

Having anything `react-native-pager-view` related in the app.

### What are the steps to reproduce (after prerequisites)?

You need to create 2 differents apps - one with RN 0.74, the other with RN 0.75 - to make sure we don't lose <0.75 compatibility. Then, after installing dependencies just try building via Android Studio.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    not relevant     |
| Android |    ✅     |

## Checklist

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
