### PR TITLE
fix: override child pages style in utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,6 @@ See the [contributing guide](CONTRIBUTING.md) to learn how to contribute to the 
 
 ## Known Issues
 
-- `flex:1` does not work for child views, please use `width: '100%', height: '100%'` [instead](https://github.com/callstack/react-native-pager-view/issues/186#issuecomment-675320732)
-
 - [iOS]: In case of `UIViewControllerHierarchyInconsistency` error, please use below fix:
 
 ```

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -23,6 +23,7 @@ export const childrenWithOverriddenStyle = (
   pageMargin = 0
 ) => {
   return Children.map(children, (child) => {
+    const element = child as React.ReactElement;
     return (
       <View
         style={{
@@ -32,7 +33,15 @@ export const childrenWithOverriddenStyle = (
         }}
         collapsable={false}
       >
-        {child}
+        {React.cloneElement(element, {
+          ...element.props,
+          style: [
+            element.props.style,
+            {
+              flex: 1,
+            },
+          ],
+        })}
       </View>
     );
   });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
Related Issue #837 
Latest change related to modifications in page wrapper caused on android to style properties not be passed anymore and initial calculation for screen height to be 0 if flex properties used on page child. 

By modifying the utils wrapper for children to actually override the child views to include the flex property it solves the given issue.

## Test Plan
![image](https://github.com/user-attachments/assets/ec8b3c2c-f82d-4616-b646-2f93e1ebc1b3)

Reproduced the example code provided and it displays correctly.
Verified existing screens in example app and everything seems to be in place.

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
