### PR TITLE
feat: remove usage of currentBridge

### DIFF
--- a/ios/Fabric/RNCPagerViewComponentView.mm
+++ b/ios/Fabric/RNCPagerViewComponentView.mm
@@ -10,7 +10,6 @@
 #import "RCTFabricComponentsPlugins.h"
 #import "React/RCTConversions.h"
 
-#import <React/RCTBridge+Private.h>
 #import "RCTOnPageScrollEvent.h"
 
 using namespace facebook::react;

--- a/ios/Fabric/RNCPagerViewComponentView.mm
+++ b/ios/Fabric/RNCPagerViewComponentView.mm
@@ -195,13 +195,10 @@ using namespace facebook::react;
     
     strongEventEmitter.onPageScroll(RNCViewPagerEventEmitter::OnPageScroll{.position =  static_cast<double>(position), .offset = offset});
     
-    //This is temporary workaround to allow animations based on onPageScroll event
-    //until Fabric implements proper NativeAnimationDriver
-    RCTBridge *bridge = [RCTBridge currentBridge];
-    
-    if (bridge) {
-        [bridge.eventDispatcher sendEvent:[[RCTOnPageScrollEvent alloc] initWithReactTag:[NSNumber numberWithInt:self.tag] position:@(position) offset:@(offset)]];
-    }
+    NSDictionary *userInfo = [NSDictionary dictionaryWithObjectsAndKeys:[[RCTOnPageScrollEvent alloc] initWithReactTag:[NSNumber numberWithInt:self.tag] position:@(position) offset:@(offset)], @"event", nil];
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"RCTNotifyEventDispatcherObserversOfEvent_DEPRECATED"
+                                                        object:nil
+                                                      userInfo:userInfo];
 }
 
 #pragma mark - Internal methods

--- a/ios/Fabric/RNCPagerViewComponentView.mm
+++ b/ios/Fabric/RNCPagerViewComponentView.mm
@@ -195,6 +195,9 @@ using namespace facebook::react;
     
     strongEventEmitter.onPageScroll(RNCViewPagerEventEmitter::OnPageScroll{.position =  static_cast<double>(position), .offset = offset});
     
+    // This is temporary workaround to allow animations based on onPageScroll event
+    // until Fabric implements proper NativeAnimationDriver,
+    // see: https://github.com/facebook/react-native/blob/44f431b471c243c92284aa042d3807ba4d04af65/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm#L59
     NSDictionary *userInfo = [NSDictionary dictionaryWithObjectsAndKeys:[[RCTOnPageScrollEvent alloc] initWithReactTag:[NSNumber numberWithInt:self.tag] position:@(position) offset:@(offset)], @"event", nil];
     [[NSNotificationCenter defaultCenter] postNotificationName:@"RCTNotifyEventDispatcherObserversOfEvent_DEPRECATED"
                                                         object:nil

--- a/ios/LEGACY/Fabric/LEGACY_RNCPagerViewComponentView.mm
+++ b/ios/LEGACY/Fabric/LEGACY_RNCPagerViewComponentView.mm
@@ -363,14 +363,10 @@ using namespace facebook::react;
     int eventPosition = (int) position;
     strongEventEmitter.onPageScroll(LEGACY_RNCViewPagerEventEmitter::OnPageScroll{.position =  static_cast<double>(eventPosition), .offset = interpolatedOffset});
 
-    //This is temporary workaround to allow animations based on onPageScroll event
-    //until Fabric implements proper NativeAnimationDriver
-    RCTBridge *bridge = [RCTBridge currentBridge];
-    
-    if (bridge) {
-        [bridge.eventDispatcher sendEvent:[[RCTOnPageScrollEvent alloc] initWithReactTag:[NSNumber numberWithInt:self.tag] position:@(position) offset:@(interpolatedOffset)]];
-    }
-    
+    NSDictionary *userInfo = [NSDictionary dictionaryWithObjectsAndKeys:[[RCTOnPageScrollEvent alloc] initWithReactTag:[NSNumber numberWithInt:self.tag] position:@(position) offset:@(interpolatedOffset)], @"event", nil];
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"RCTNotifyEventDispatcherObserversOfEvent_DEPRECATED"
+                                                        object:nil
+                                                      userInfo:userInfo];
 }
 
 

--- a/ios/LEGACY/Fabric/LEGACY_RNCPagerViewComponentView.mm
+++ b/ios/LEGACY/Fabric/LEGACY_RNCPagerViewComponentView.mm
@@ -363,6 +363,9 @@ using namespace facebook::react;
     int eventPosition = (int) position;
     strongEventEmitter.onPageScroll(LEGACY_RNCViewPagerEventEmitter::OnPageScroll{.position =  static_cast<double>(eventPosition), .offset = interpolatedOffset});
 
+    // This is temporary workaround to allow animations based on onPageScroll event
+    // until Fabric implements proper NativeAnimationDriver,
+    // see: https://github.com/facebook/react-native/blob/44f431b471c243c92284aa042d3807ba4d04af65/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm#L59
     NSDictionary *userInfo = [NSDictionary dictionaryWithObjectsAndKeys:[[RCTOnPageScrollEvent alloc] initWithReactTag:[NSNumber numberWithInt:self.tag] position:@(position) offset:@(interpolatedOffset)], @"event", nil];
     [[NSNotificationCenter defaultCenter] postNotificationName:@"RCTNotifyEventDispatcherObserversOfEvent_DEPRECATED"
                                                         object:nil

--- a/ios/LEGACY/Fabric/LEGACY_RNCPagerViewComponentView.mm
+++ b/ios/LEGACY/Fabric/LEGACY_RNCPagerViewComponentView.mm
@@ -10,7 +10,6 @@
 #import "RCTFabricComponentsPlugins.h"
 #import "React/RCTConversions.h"
 
-#import <React/RCTBridge+Private.h>
 #import "RCTOnPageScrollEvent.h"
 
 using namespace facebook::react;


### PR DESCRIPTION
## PR concerning New Architecture support in the library :tada:

We at [Software Mansion](https://swmansion.com/) have been working on [improving support](https://blog.swmansion.com/sunrising-new-architecture-in-the-new-expensify-app-729d237a02f5) for the new architecture for quite a while now. If you need help with anything related to New Architecture, like:
- [migrating your library](https://x.com/swmansion/status/1717512089323864275)
- [migrating your app](https://github.com/Expensify/App/pull/13767)
- [investigating issues](https://github.com/facebook/react-native/pulls?q=sort%3Aupdated-desc+is%3Apr+author%3Aj-piasecki+is%3Aopen)
- [improving performance](https://x.com/BBloniarz_/status/1808138585528303977)

or you just want to ask any questions, hit us up on [projects@swmansion.com](mailto:projects@swmansion.com)

---

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

### Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

Since https://github.com/facebook/react-native/pull/44474 has been merged, we should also remove the code using `currentBridge`, same as in RNScreens: https://github.com/software-mansion/react-native-screens/pull/2218/files#diff-ad35cf2dc9a86855afc1d2443a42a133ccf0dd8b17589719cb1aab4a81d20604
