### PR TITLE
chore(android): bump android ViewPager2 to 1.1.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -226,7 +226,7 @@ dependencies {
     //noinspection GradleDynamicVersion
   api "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation 'androidx.viewpager2:viewpager2:1.0.0'
+  implementation 'androidx.viewpager2:viewpager2:1.1.0'
 }
 
 if (isNewArchitectureEnabled()) {


### PR DESCRIPTION
# Summary

Closes https://github.com/callstack/react-native-pager-view/issues/879 
Closes https://github.com/callstack/react-native-pager-view/issues/744
Closes https://github.com/react-navigation/react-navigation/issues/11473
Closes https://github.com/callstack/react-native-pager-view/issues/692

