### PR TITLE
fix(ios): Fix vertical list scroll directionin rtl

### DIFF
--- a/ios/LEGACY/Fabric/LEGACY_RNCPagerViewComponentView.h
+++ b/ios/LEGACY/Fabric/LEGACY_RNCPagerViewComponentView.h
@@ -4,10 +4,11 @@
 #import <Foundation/Foundation.h>
 #import <React/RCTViewComponentView.h>
 #import "UIViewController+CreateExtension.h"
+#import "UIView+isHorizontalRtlLayout.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface LEGACY_RNCPagerViewComponentView : RCTViewComponentView <UIPageViewControllerDataSource, UIPageViewControllerDelegate, UIScrollViewDelegate>
+@interface LEGACY_RNCPagerViewComponentView : RCTViewComponentView <UIPageViewControllerDataSource, UIPageViewControllerDelegate, UIScrollViewDelegate, isHorizontalRtlLayout>
 
 @property(strong, nonatomic, readonly) UIPageViewController *nativePageViewController;
 @property(nonatomic, strong) NSMutableArray<UIViewController *> *nativeChildrenViewControllers;

--- a/ios/LEGACY/Fabric/LEGACY_RNCPagerViewComponentView.mm
+++ b/ios/LEGACY/Fabric/LEGACY_RNCPagerViewComponentView.mm
@@ -309,10 +309,6 @@ using namespace facebook::react;
     return [_layoutDirection isEqualToString: @"ltr"];
 }
 
-- (BOOL)isHorizontalRtlLayout {
-    return self.isHorizontal && ![self isLtrLayout];
-}
-
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView {
     CGPoint point = scrollView.contentOffset;
     

--- a/ios/LEGACY/Fabric/LEGACY_RNCPagerViewComponentView.mm
+++ b/ios/LEGACY/Fabric/LEGACY_RNCPagerViewComponentView.mm
@@ -309,6 +309,10 @@ using namespace facebook::react;
     return [_layoutDirection isEqualToString: @"ltr"];
 }
 
+- (BOOL)isHorizontalRtlLayout {
+    return self.isHorizontal && ![self isLtrLayout];
+}
+
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView {
     CGPoint point = scrollView.contentOffset;
     
@@ -328,6 +332,7 @@ using namespace facebook::react;
     
     NSInteger position = self.currentIndex;
     
+    BOOL isHorizontalRtl = [self isHorizontalRtlLayout];
     BOOL isAnimatingBackwards = offset<0;
     
     if (scrollView.isDragging) {
@@ -341,8 +346,8 @@ using namespace facebook::react;
     
     if (!_overdrag) {
         NSInteger maxIndex = _nativeChildrenViewControllers.count - 1;
-        NSInteger firstPageIndex = [self isLtrLayout] ?  0 :  maxIndex;
-        NSInteger lastPageIndex = [self isLtrLayout] ?  maxIndex :  0;
+        NSInteger firstPageIndex = !isHorizontalRtl ? 0 :  maxIndex;
+        NSInteger lastPageIndex = !isHorizontalRtl ? maxIndex :  0;
         BOOL isFirstPage = _currentIndex == firstPageIndex;
         BOOL isLastPage = _currentIndex == lastPageIndex;
         CGFloat contentOffset =[self isHorizontal] ? scrollView.contentOffset.x : scrollView.contentOffset.y;

--- a/ios/LEGACY/LEGACY_RNCPagerView.h
+++ b/ios/LEGACY/LEGACY_RNCPagerView.h
@@ -2,10 +2,11 @@
 #import <React/RCTShadowView.h>
 #import <React/UIView+React.h>
 #import <UIKit/UIKit.h>
+#import "UIView+isHorizontalRtlLayout.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface LEGACY_RNCPagerView: UIView
+@interface LEGACY_RNCPagerView: UIView <RtlLayoutProtocol>
 
 - (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher;
 

--- a/ios/LEGACY/LEGACY_RNCPagerView.m
+++ b/ios/LEGACY/LEGACY_RNCPagerView.m
@@ -260,11 +260,9 @@
         return;
     }
     
-    BOOL isRTL = ![self isLtrLayout];
-    
-    BOOL isForward = (index > self.currentIndex && !isRTL) || (index < self.currentIndex && isRTL);
+    BOOL isHorizontalRtl = [self isHorizontalRtlLayout];
+    BOOL isForward = isHorizontalRtl ? index < self.currentIndex : index > self.currentIndex;
 
-    
     UIPageViewControllerNavigationDirection direction = isForward ? UIPageViewControllerNavigationDirectionForward : UIPageViewControllerNavigationDirectionReverse;
     
     long diff = labs(index - _currentIndex);
@@ -353,13 +351,13 @@
 
 - (UIViewController *)pageViewController:(UIPageViewController *)pageViewController
        viewControllerAfterViewController:(UIViewController *)viewController {
-    UIPageViewControllerNavigationDirection direction = [self isLtrLayout] ? UIPageViewControllerNavigationDirectionForward : UIPageViewControllerNavigationDirectionReverse;
+    UIPageViewControllerNavigationDirection direction = ![self isHorizontalRtlLayout] ? UIPageViewControllerNavigationDirectionForward : UIPageViewControllerNavigationDirectionReverse;
     return [self nextControllerForController:viewController inDirection:direction];
 }
 
 - (UIViewController *)pageViewController:(UIPageViewController *)pageViewController
       viewControllerBeforeViewController:(UIViewController *)viewController {
-    UIPageViewControllerNavigationDirection direction = [self isLtrLayout] ? UIPageViewControllerNavigationDirectionReverse : UIPageViewControllerNavigationDirectionForward;
+    UIPageViewControllerNavigationDirection direction = ![self isHorizontalRtlLayout] ? UIPageViewControllerNavigationDirectionReverse : UIPageViewControllerNavigationDirectionForward;
     return [self nextControllerForController:viewController inDirection:direction];
 }
 
@@ -382,8 +380,8 @@
     
     if (!_overdrag) {
         NSInteger maxIndex = self.reactSubviews.count - 1;
-        BOOL isFirstPage = [self isLtrLayout] ? _currentIndex == 0 : _currentIndex == maxIndex;
-        BOOL isLastPage = [self isLtrLayout] ? _currentIndex == maxIndex : _currentIndex == 0;
+        BOOL isFirstPage = ![self isHorizontalRtlLayout] ? _currentIndex == 0 : _currentIndex == maxIndex;
+        BOOL isLastPage = ![self isHorizontalRtlLayout] ? _currentIndex == maxIndex : _currentIndex == 0;
         CGFloat contentOffset =[self isHorizontal] ? scrollView.contentOffset.x : scrollView.contentOffset.y;
         CGFloat topBound = [self isHorizontal] ? scrollView.bounds.size.width : scrollView.bounds.size.height;
         
@@ -423,7 +421,8 @@
     
     NSInteger position = self.currentIndex;
     
-    BOOL isAnimatingBackwards = ([self isLtrLayout] && offset<0) || (![self isLtrLayout] && offset > 0.05f);
+    BOOL isHorizontalRtl = [self isHorizontalRtlLayout];
+    BOOL isAnimatingBackwards = isHorizontalRtl ? offset > 0.05f : offset < 0;
     
     if (scrollView.isDragging) {
         _destinationIndex = isAnimatingBackwards ? _currentIndex - 1 : _currentIndex + 1;
@@ -436,8 +435,8 @@
     
     if (!_overdrag) {
         NSInteger maxIndex = self.reactSubviews.count - 1;
-        NSInteger firstPageIndex = [self isLtrLayout] ?  0 :  maxIndex;
-        NSInteger lastPageIndex = [self isLtrLayout] ?  maxIndex :  0;
+        NSInteger firstPageIndex = !isHorizontalRtl ? 0 : maxIndex;
+        NSInteger lastPageIndex = !isHorizontalRtl ? maxIndex : 0;
         BOOL isFirstPage = _currentIndex == firstPageIndex;
         BOOL isLastPage = _currentIndex == lastPageIndex;
         CGFloat contentOffset =[self isHorizontal] ? scrollView.contentOffset.x : scrollView.contentOffset.y;
@@ -499,5 +498,9 @@
 
 - (BOOL)isLtrLayout {
     return [_layoutDirection isEqualToString:@"ltr"];
+}
+
+- (BOOL)isHorizontalRtlLayout {
+    return self.isHorizontal && ![self isLtrLayout];
 }
 @end

--- a/ios/LEGACY/LEGACY_RNCPagerView.m
+++ b/ios/LEGACY/LEGACY_RNCPagerView.m
@@ -500,7 +500,4 @@
     return [_layoutDirection isEqualToString:@"ltr"];
 }
 
-- (BOOL)isHorizontalRtlLayout {
-    return self.isHorizontal && ![self isLtrLayout];
-}
 @end

--- a/ios/UIView+isHorizontalRtlLayout.h
+++ b/ios/UIView+isHorizontalRtlLayout.h
@@ -1,0 +1,14 @@
+#import <UIKit/UIKit.h>
+
+@protocol RtlLayoutProtocol <NSObject>
+
+@property (nonatomic, readonly) BOOL isHorizontal;
+@property (nonatomic, readonly) BOOL isLtrLayout;
+
+@end
+
+@interface UIView (RtlLayoutProtocol)
+
+- (BOOL)isHorizontalRtlLayout;
+
+@end

--- a/ios/UIView+isHorizontalRtlLayout.m
+++ b/ios/UIView+isHorizontalRtlLayout.m
@@ -1,0 +1,14 @@
+#import "UIView+isHorizontalRtlLayout.h"
+
+
+@implementation UIView (RtlLayoutProtocol)
+
+- (BOOL)isHorizontalRtlLayout {
+    if ([self conformsToProtocol:@protocol(RtlLayoutProtocol)]) {
+        id<RtlLayoutProtocol> layoutObject = (id<RtlLayoutProtocol>)self;
+        return layoutObject.isHorizontal && !layoutObject.isLtrLayout;
+    }
+    return NO;
+}
+
+@end


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

When in RTL, vertical pager view is scrolling backwards. This is unwanted behavior (only horizontal axis should be inverted in RTL).

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

Test LTR & RTL in legacy pager view.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
