### PR TITLE
fix(iOS): fix component layout issue

### DIFF
--- a/example/src/HeadphonesCarouselExample.tsx
+++ b/example/src/HeadphonesCarouselExample.tsx
@@ -261,9 +261,10 @@ export default function HeadphonesCarouselExample() {
           }
         )}
       >
-        {data.map((item, index) => (
+        {data.map(({ key, ...item }, index) => (
           <View collapsable={false} key={index}>
             <Item
+              key={key}
               {...item}
               scrollOffsetAnimatedValue={scrollOffsetAnimatedValue}
               positionAnimatedValue={positionAnimatedValue}

--- a/ios/LEGACY/Fabric/LEGACY_RNCPagerViewComponentView.mm
+++ b/ios/LEGACY/Fabric/LEGACY_RNCPagerViewComponentView.mm
@@ -92,14 +92,13 @@ using namespace facebook::react;
 #pragma mark - React API
 
 - (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index {
-    UIViewController *wrapper = [[UIViewController alloc] initWithView:childComponentView];
-    [_nativeChildrenViewControllers insertObject:wrapper atIndex:index];
-    [self goTo:_currentIndex animated:NO];
+    UIViewController *vc = [UIViewController new];
+    [vc.view addSubview:childComponentView];
+    [_nativeChildrenViewControllers insertObject:vc atIndex:index];
 }
 
 - (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index {
-    [[_nativeChildrenViewControllers objectAtIndex:index].view removeFromSuperview];
-    [_nativeChildrenViewControllers objectAtIndex:index].view = nil;
+    [childComponentView removeFromSuperview];
     [_nativeChildrenViewControllers removeObjectAtIndex:index];
  
     NSInteger maxPage = _nativeChildrenViewControllers.count - 1;
@@ -119,11 +118,7 @@ using namespace facebook::react;
 
 -(void)prepareForRecycle {
     [super prepareForRecycle];
-    
-    _nativeChildrenViewControllers = [[NSMutableArray alloc] init];
-    [_nativePageViewController.view removeFromSuperview];
     _nativePageViewController = nil;
-    
     _currentIndex = -1;
 }
 


### PR DESCRIPTION
# Summary

This PR fixes issue with views not being correctly recycled on new arch, causing components styles miscalculations

## Test Plan

1. Open example app
2. Navigate through examples a lot – e.g `BasicExample` -> `PaginationDotsExample` -> `HeadphonesExample` -> again `PaginationDotsExample` etc.
3. No layout issues should appear, rest should work as before

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |
