### PR TITLE
fix(paper): prevent freeze on layout update during transition

### DIFF
--- a/ios/RNCPagerView.h
+++ b/ios/RNCPagerView.h
@@ -1,14 +1,14 @@
+#import <React/RCTView.h>
 #import <React/RCTEventDispatcher.h>
 #import <React/RCTShadowView.h>
-#import <React/UIView+React.h>
 #import <UIKit/UIKit.h>
 #import "UIView+isHorizontalRtlLayout.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface RNCPagerView: UIView <RtlLayoutProtocol>
+@interface RNCPagerView: RCTView <RtlLayoutProtocol>
 
-- (instancetype)initWithEventDispatcher:(id<RCTEventDispatcherProtocol> )eventDispatcher;
+- (instancetype)initWithBridge:(RCTBridge *)bridge;
 
 @property(nonatomic) NSInteger initialPage;
 @property(nonatomic) NSInteger lastReportedIndex;
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, copy) RCTDirectEventBlock onPageScrollStateChanged;
 @property(nonatomic) BOOL overdrag;
 @property(nonatomic) NSString* layoutDirection;
-@property(nonatomic, assign) BOOL animating;
+@property(nonatomic, assign) BOOL transitioning;
 
 - (void)goTo:(NSInteger)index animated:(BOOL)animated;
 - (void)shouldScroll:(BOOL)scrollEnabled;

--- a/ios/RNCPagerView.m
+++ b/ios/RNCPagerView.m
@@ -1,6 +1,7 @@
 #import "RNCPagerView.h"
 #import "React/RCTLog.h"
 #import <React/RCTViewManager.h>
+#import <React/RCTUIManager.h>
 
 #import "UIViewController+CreateExtension.h"
 #import "RCTOnPageScrollEvent.h"
@@ -13,7 +14,7 @@
 @property(nonatomic, assign) UIPanGestureRecognizer* panGestureRecognizer;
 
 @property(nonatomic, strong) UIPageViewController *reactPageViewController;
-@property(nonatomic, strong) RCTEventDispatcher *eventDispatcher;
+@property(nonatomic, strong) id<RCTEventDispatcherProtocol> eventDispatcher;
 
 @property(nonatomic, weak) UIScrollView *scrollView;
 @property(nonatomic, weak) UIView *currentView;
@@ -30,10 +31,12 @@
 
 @implementation RNCPagerView {
     uint16_t _coalescingKey;
+  __weak RCTBridge * _bridge;
 }
 
-- (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher {
+- (instancetype)initWithBridge:(RCTBridge *)bridge {
     if (self = [super init]) {
+        _bridge = bridge;
         _scrollEnabled = YES;
         _pageMargin = 0;
         _lastReportedIndex = -1;
@@ -44,7 +47,7 @@
         _dismissKeyboard = UIScrollViewKeyboardDismissModeNone;
 #endif
         _coalescingKey = 0;
-        _eventDispatcher = eventDispatcher;
+        _eventDispatcher = bridge.eventDispatcher;
         _cachedControllers = [NSHashTable hashTableWithOptions:NSHashTableStrongMemory];
         _overdrag = NO;
         _layoutDirection = @"ltr";
@@ -178,7 +181,7 @@
     uint16_t coalescingKey = _coalescingKey++;
     
     if (animated == YES) {
-        self.animating = YES;
+      [self setTransitioning:YES];
     }
     
     [self.reactPageViewController setViewControllers:@[controller]
@@ -190,10 +193,8 @@
         strongSelf.currentView = controller.view;
         
         [strongSelf enableSwipe];
-        
-        if (finished) {
-            strongSelf.animating = NO;
-        }
+
+        [strongSelf setTransitioning:NO];
         
         if (strongSelf.eventDispatcher) {
             if (strongSelf.lastReportedIndex != strongSelf.currentIndex) {
@@ -245,6 +246,11 @@
     self.reactPageViewController.view.userInteractionEnabled = YES;
 }
 
+- (void)setTransitioning:(BOOL)transitioning {
+  _transitioning = transitioning;
+  [_bridge.uiManager setLocalData:@{@"transitioning": @(transitioning)} forView:self];
+}
+
 - (void)goTo:(NSInteger)index animated:(BOOL)animated {
     NSInteger numberOfPages = self.reactSubviews.count;
     
@@ -267,7 +273,7 @@
     
     long diff = labs(index - _currentIndex);
     
-    [self goToViewController:index direction:direction animated:(!self.animating && animated) shouldCallOnPageSelected: YES];
+    [self goToViewController:index direction:direction animated:(!_transitioning && animated) shouldCallOnPageSelected: YES];
     
     if (diff == 0) {
         [self goToViewController:index direction:direction animated:NO shouldCallOnPageSelected:YES];

--- a/ios/RNCPagerViewManager.m
+++ b/ios/RNCPagerViewManager.m
@@ -1,5 +1,6 @@
 
 #import "RNCPagerViewManager.h"
+#import "RNCPagerViewShadowView.h"
 
 @implementation RNCPagerViewManager
 
@@ -30,7 +31,7 @@ RCT_EXPORT_VIEW_PROPERTY(layoutDirection, NSString)
             RCTLogError(@"Cannot find RNCPagerView with tag #%@", reactTag);
             return;
         }
-        if (!animated || !view.animating) {
+        if (!animated || !view.transitioning) {
             [view goTo:index.integerValue animated:animated];
         }
     }];
@@ -80,7 +81,12 @@ RCT_CUSTOM_VIEW_PROPERTY(keyboardDismissMode, NSString, RNCPagerView) {
 
 
 - (UIView *)view {
-    return [[RNCPagerView alloc] initWithEventDispatcher:self.bridge.eventDispatcher];
+    return [[RNCPagerView alloc] initWithBridge: self.bridge];
+}
+
+
+- (RCTShadowView *)shadowView {
+  return [RNCPagerViewShadowView new];
 }
 
 @end

--- a/ios/RNCPagerViewShadowView.h
+++ b/ios/RNCPagerViewShadowView.h
@@ -1,0 +1,5 @@
+#import <React/RCTShadowView.h>
+
+@interface RNCPagerViewShadowView : RCTShadowView
+
+@end

--- a/ios/RNCPagerViewShadowView.m
+++ b/ios/RNCPagerViewShadowView.m
@@ -1,0 +1,22 @@
+#import "RNCPagerViewShadowView.h"
+
+@implementation RNCPagerViewShadowView {
+  BOOL _transitioning;
+}
+
+- (void)layoutWithMetrics:(RCTLayoutMetrics)layoutMetrics
+            layoutContext:(RCTLayoutContext)layoutContext {
+    if (_transitioning) {
+      return;
+    }
+  
+    [super layoutWithMetrics:layoutMetrics layoutContext:layoutContext];
+}
+
+- (void)setLocalData:(NSDictionary *)localData {
+    [super setLocalData:localData];
+  
+    _transitioning = [localData[@"transitioning"] boolValue];
+}
+
+@end


### PR DESCRIPTION
# Summary
This PR fixes issue causing component to freeze when layout was updated during transition - old arch

When layout was updated e.g. because of hiding keyboard, setViewControllers completion block was never called, which resulted in swipe being disabled

It fixes this issue by adding custom shadow view and preventing layout update during transition phase

## Test Plan

1. Build the example app.
2. Go to the Keyboard Example menu.
3. Touch the TextInput to show the keyboard.
4. Press the Next page button. (might be required to modify ControlPanel to move button above keyboard)
5. Should navigate correctly, should be able to interact

Other examples should work as before

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |


