### PR TITLE
fix(android): prevent views from being recycled

### DIFF
--- a/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt
+++ b/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt
@@ -17,6 +17,7 @@ class ViewPagerAdapter() : Adapter<ViewPagerViewHolder>() {
   override fun onBindViewHolder(holder: ViewPagerViewHolder, index: Int) {
     val container: FrameLayout = holder.container
     val child = getChildAt(index)
+    holder.setIsRecyclable(false)
 
     if (container.childCount > 0) {
       container.removeAllViews()


### PR DESCRIPTION
# Summary

This PR fixes issue causing crash on Android - both architectures

Fixes #942 #859 #173 


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |
