### PR TITLE
feat: add component provider field for codegen

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,6 +126,11 @@
     "jsSrcsDir": "src",
     "android": {
       "javaPackageName": "com.reactnativepagerview"
+    },
+    "ios": {
+      "componentProvider": {
+        "RNCViewPager": "RNCPagerViewComponentView"
+      }
     }
   },
   "react-native-builder-bob": {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

When installing this package with RN 0.77 there's a warning related to the missing field in `codegenConfig`, this PR fixes it 👍

## Test Plan

1. Create an app with 0.77
2. Apply diff from this PR
3. The warning shouldn't be no longer produced

### What's required for testing (prerequisites)?

RN 0.77

### What are the steps to reproduce (after prerequisites)?

Running `pod install`.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [x] I updated the typed files (TS and Flow)
