### PR TITLE
fix(android): prevent taps while scrolling

### DIFF
--- a/android/src/main/java/com/reactnativepagerview/NestedScrollableHost.kt
+++ b/android/src/main/java/com/reactnativepagerview/NestedScrollableHost.kt
@@ -8,6 +8,7 @@ import android.view.ViewConfiguration
 import android.widget.FrameLayout
 import androidx.viewpager2.widget.ViewPager2
 import androidx.viewpager2.widget.ViewPager2.ORIENTATION_HORIZONTAL
+import com.facebook.react.uimanager.events.NativeGestureUtil
 import kotlin.math.absoluteValue
 import kotlin.math.sign
 
@@ -57,17 +58,14 @@ class NestedScrollableHost : FrameLayout {
   }
 
   private fun handleInterceptTouchEvent(e: MotionEvent) {
-    val orientation = parentViewPager?.orientation ?: return
-
-    // Early return if child can't scroll in same direction as parent
-    if (!canChildScroll(orientation, -1f) && !canChildScroll(orientation, 1f)) {
-      return
-    }
+    val orientation = parentViewPager?.orientation
 
     if (e.action == MotionEvent.ACTION_DOWN) {
       initialX = e.x
       initialY = e.y
-      parent.requestDisallowInterceptTouchEvent(true)
+      if (orientation != null) {
+        parent.requestDisallowInterceptTouchEvent(true)
+      }
     } else if (e.action == MotionEvent.ACTION_MOVE) {
       val dx = e.x - initialX
       val dy = e.y - initialY
@@ -78,6 +76,9 @@ class NestedScrollableHost : FrameLayout {
       val scaledDy = dy.absoluteValue * if (isVpHorizontal) 1f else .5f
 
       if (scaledDx > touchSlop || scaledDy > touchSlop) {
+        NativeGestureUtil.notifyNativeGestureStarted(this, e)
+
+        if (orientation == null) return
         if (isVpHorizontal == (scaledDy > scaledDx)) {
           // Gesture is perpendicular, allow all parents to intercept
           parent.requestDisallowInterceptTouchEvent(false)

--- a/android/src/main/java/com/reactnativepagerview/NestedScrollableHost.kt
+++ b/android/src/main/java/com/reactnativepagerview/NestedScrollableHost.kt
@@ -28,6 +28,7 @@ class NestedScrollableHost : FrameLayout {
   private var touchSlop = 0
   private var initialX = 0f
   private var initialY = 0f
+  private var nativeGestureStarted: Boolean = false
   private val parentViewPager: ViewPager2?
     get() {
       var v: View? = parent as? View
@@ -77,6 +78,7 @@ class NestedScrollableHost : FrameLayout {
 
       if (scaledDx > touchSlop || scaledDy > touchSlop) {
         NativeGestureUtil.notifyNativeGestureStarted(this, e)
+        nativeGestureStarted = true
 
         if (orientation == null) return
         if (isVpHorizontal == (scaledDy > scaledDx)) {
@@ -94,5 +96,15 @@ class NestedScrollableHost : FrameLayout {
         }
       }
     }
+  }
+
+  override fun onTouchEvent(e: MotionEvent): Boolean {
+    if (e.actionMasked == MotionEvent.ACTION_UP) {
+      if (nativeGestureStarted) {
+        NativeGestureUtil.notifyNativeGestureEnded(this, e)
+        nativeGestureStarted = false
+      }
+    }
+    return super.onTouchEvent(e)
   }
 }


### PR DESCRIPTION
# Summary

This PR fixes a bug on Android where taps sometimes incorrectly trigger while swiping between pager screens, see issues https://github.com/callstack/react-native-pager-view/issues/960 and https://github.com/callstack/react-native-pager-view/issues/954. These issues in turn were opened in order to investigate https://github.com/bluesky-social/social-app/pull/7312
The cause of the bug seems to have had to do with React not being notified when the native pager starts scrolling, which meant that it didn't properly cancel gestures in the pager's children.

The fix involves adding a call to [notifyNativeGestureStarted](https://github.com/facebook/react-native/blob/c65117eba9f16da023e99253bfe28c0858f332fd/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/NativeGestureUtil.kt), whose purpose is exactly to notify JS that a native gesture has started so it can dispatch the appropriate cancel events, see its use in other similar components like [ReactScrollView](https://github.com/facebook/react-native/blob/c65117eba9f16da023e99253bfe28c0858f332fd/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java#L454)

This call was added to NestedScrollableHost, where scrolling canceling logic was already present, however the behavior of nested scrollables should hopefully remain unchanged.

## Test Plan

I have tested the issues this PR aims to solve (https://github.com/callstack/react-native-pager-view/issues/960, https://github.com/callstack/react-native-pager-view/issues/954, https://github.com/bluesky-social/social-app/pull/7312) and I cannot reproduce the described bugs anymore. 
I have also tested all the examples in the repo, and all seem to function as expected. In particular, examples with scrollables (eg. ScrollViewInsideExample) or nested pagers (eg. NestPagerView) seem to be unaffected. 

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
