### PR TITLE
fix: Remove nullability of command id

### DIFF
--- a/android/src/fabric/java/com/reactnativepagerview/PagerViewViewManager.kt
+++ b/android/src/fabric/java/com/reactnativepagerview/PagerViewViewManager.kt
@@ -37,7 +37,7 @@ class PagerViewViewManager : ViewGroupManager<NestedScrollableHost>(), RNCViewPa
         return PagerViewViewManagerImpl.NAME
     }
 
-    override fun receiveCommand(root: NestedScrollableHost, commandId: String?, args: ReadableArray?) {
+    override fun receiveCommand(root: NestedScrollableHost, commandId: String, args: ReadableArray?) {
         mDelegate.receiveCommand(root, commandId, args)
     }
 

--- a/android/src/paper/java/com/reactnativepagerview/PagerViewViewManager.kt
+++ b/android/src/paper/java/com/reactnativepagerview/PagerViewViewManager.kt
@@ -132,7 +132,7 @@ class PagerViewViewManager : ViewGroupManager<NestedScrollableHost>() {
                 PageSelectedEvent.EVENT_NAME, MapBuilder.of("registrationName", "onPageSelected"))
     }
 
-    override fun receiveCommand(root: NestedScrollableHost, commandId: String?, args: ReadableArray?) {
+    override fun receiveCommand(root: NestedScrollableHost, commandId: String, args: ReadableArray?) {
         super.receiveCommand(root, commandId, args)
         val view = PagerViewViewManagerImpl.getViewPager(root)
         Assertions.assertNotNull(view)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

This PR applies necessary changes for RN 0.79. Before this change the library won't compile on android on RN 0.79. This change is needed because of [this](https://github.com/facebook/react-native/commit/5a290c4cab6f58744a9252687feefd8b6a8d3305) commit in `react-native`.

## Test Plan

- clone [this](https://github.com/MatiPl01/react-native-pager-view-issues) repo (clean app with RN 0.79-rc.3 and latest `react-native-pager-view`)
  - `git clone https://github.com/MatiPl01/react-native-pager-view-issues.git`
- `cd react-native-pager-view-issues && git switch 0.79-android-build`
- build the app for android and observe the error (`Argument type mismatch: actual type is 'kotlin.String?', but 'kotlin.String' was expected.`)
- install library witch changes from this PR
  - `npm install git+https://github.com/MatiPl01/react-native-pager-view.git#fix/remove-nullability-of-command-id-arg`
- build the app for android again and see that build succeeds

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |     ✅     |
| Android |     ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
