### PR TITLE
fix(fabric): update receiveCommand params for RN 0.79 support

### DIFF
--- a/android/src/fabric/java/com/reactnativepagerview/PagerViewViewManager.kt
+++ b/android/src/fabric/java/com/reactnativepagerview/PagerViewViewManager.kt
@@ -37,7 +37,7 @@ class PagerViewViewManager : ViewGroupManager<NestedScrollableHost>(), RNCViewPa
         return PagerViewViewManagerImpl.NAME
     }
 
-    override fun receiveCommand(root: NestedScrollableHost, commandId: String?, args: ReadableArray?) {
+    override fun receiveCommand(root: NestedScrollableHost, commandId: String, args: ReadableArray?) {
         mDelegate.receiveCommand(root, commandId, args)
     }
 


### PR DESCRIPTION
# Summary

https://github.com/facebook/react-native/pull/48602 made commandId non-nullable. This PR reflects that change and makes sure the library will build on RN 0.79.

## Test Plan

Tested this diff locally in my own project and worked fine. Haven't updated the example app to RN 0.79 for full validation within this repo.

### What's required for testing (prerequisites)?

Create a new RN app and install `react-native-pager-view`. The build will fail without this diff.

### What are the steps to reproduce (after prerequisites)?

Apply this diff, the build will succeed.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
