### PR TITLE
fix(android): fix crash on pager unmount

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -95,7 +95,7 @@ const Stack = createStackNavigator();
 const NativeStack = createNativeStackNavigator();
 
 export function Navigation() {
-  const [mode, setMode] = React.useState<'native' | 'js'>('js');
+  const [mode, setMode] = React.useState<'native' | 'js'>('native');
   const NavigationStack = mode === 'js' ? Stack : NativeStack;
   return (
     <SafeAreaProvider>

--- a/example/src/OnPageScrollExample.tsx
+++ b/example/src/OnPageScrollExample.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { StyleSheet, Text, View, SafeAreaView, Animated } from 'react-native';
+import { StyleSheet, Text, View, SafeAreaView, Animated, ScrollView, TouchableOpacity } from 'react-native';
 import PagerView from 'react-native-pager-view';
-import { ScrollView, TouchableOpacity } from 'react-native-gesture-handler';
 import { ProgressBar } from './component/ProgressBar';
 import { useNavigationPanel } from './hook/useNavigationPanel';
 


### PR DESCRIPTION
# Summary

This PR fixes issue with crashing on android when leaving screen using native stack

Root cause of that crash was that component tried to call queued `refreshViewChildrenLayout` on unmounted views - when leaving screen all of pages were firstly being unmounted and then `refreshViewChildrenLayout` method was called

Fixes #946 #859 

## Test Plan

1. Open example app on android with native stack
2. Go to any example
3. Go back to example list
4. App shouldn't crash
