### PR TITLE
fix: pager reporting incorrect position when being moved by nested scroll view

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -36,6 +36,7 @@ import { MaterialTopBarExample } from './MaterialTopTabExample';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { PagerHookExample } from './PagerHookExample';
+import { NestedHorizontalScrollViewExample } from './NestedHorizontalScrollViewExample';
 
 const examples = [
   { component: BasicPagerViewExample, name: 'Basic Example' },
@@ -50,7 +51,10 @@ const examples = [
     component: ScrollablePagerViewExample,
     name: 'Scrollable PagerView Example',
   },
-  { component: TabViewInsideScrollViewExample, name: 'TabView inside ScrollView Example' },
+  {
+    component: TabViewInsideScrollViewExample,
+    name: 'TabView inside ScrollView Example',
+  },
   {
     component: ScrollViewInsideExample,
     name: 'ScrollView inside PagerView Example',
@@ -60,6 +64,10 @@ const examples = [
     name: 'Nest PagerView Example',
   },
   { component: ScrollableTabBarExample, name: 'ScrollableTabBarExample' },
+  {
+    component: NestedHorizontalScrollViewExample,
+    name: 'NestedHorizontalScrollViewExample',
+  },
   { component: AutoWidthTabBarExample, name: 'AutoWidthTabBarExample' },
   { component: TabBarIconExample, name: 'TabBarIconExample' },
   { component: CustomIndicatorExample, name: 'CustomIndicatorExample' },

--- a/example/src/NestedHorizontalScrollViewExample.tsx
+++ b/example/src/NestedHorizontalScrollViewExample.tsx
@@ -1,0 +1,105 @@
+import React, { useMemo } from 'react';
+import {
+  StyleSheet,
+  View,
+  SafeAreaView,
+  Animated,
+  Text,
+  ScrollView,
+} from 'react-native';
+
+import PagerView from 'react-native-pager-view';
+
+import { LikeCount } from './component/LikeCount';
+import { NavigationPanel } from './component/NavigationPanel';
+import { useNavigationPanel } from './hook/useNavigationPanel';
+
+const AnimatedPagerView = Animated.createAnimatedComponent(PagerView);
+
+/**
+ * When dragging the horizontal ScrollView inside the PagerView, it can slightly push pager view into a different page.
+ * This is because scrollview in the same direction overdrags the outer scrollview (pager view).
+ * This example reproduces this behavior.
+ * Go to the second page and try to drag the horizontal scrollview.
+ */
+export function NestedHorizontalScrollViewExample() {
+  const { ref, ...navigationPanel } = useNavigationPanel(3);
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <AnimatedPagerView
+        {...navigationPanel}
+        testID="pager-view"
+        ref={ref}
+        style={styles.PagerView}
+        initialPage={0}
+        pageMargin={10}
+      >
+        {useMemo(
+          () =>
+            navigationPanel.pages.map((page, index) => {
+              if (index === 1) {
+                return (
+                  <ScrollView
+                    horizontal
+                    key={page.key}
+                    contentContainerStyle={{ margin: 20 }}
+                  >
+                    <View
+                      style={[styles.box, { backgroundColor: 'lightblue' }]}
+                    >
+                      <Text
+                        testID={`pageNumber${index}`}
+                      >{`Scroll View page number ${index}`}</Text>
+                    </View>
+                    <View style={styles.box}>
+                      <Text
+                        testID={`pageNumber${index}`}
+                      >{`Scroll View page number ${index}`}</Text>
+                    </View>
+                  </ScrollView>
+                );
+              }
+
+              return (
+                <View
+                  testID="pager-view-content"
+                  key={page.key}
+                  style={page.style}
+                  collapsable={false}
+                >
+                  <LikeCount />
+                  <Text
+                    testID={`pageNumber${index}`}
+                  >{`page number ${index}`}</Text>
+                </View>
+              );
+            }),
+          [navigationPanel.pages]
+        )}
+      </AnimatedPagerView>
+      <NavigationPanel {...navigationPanel} />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: 'white',
+  },
+  image: {
+    width: 300,
+    height: 200,
+    padding: 20,
+  },
+  PagerView: {
+    flex: 1,
+  },
+  box: {
+    width: 300,
+    height: '100%',
+    backgroundColor: 'lightgreen',
+    padding: 20,
+  },
+});


### PR DESCRIPTION
# Summary

This PR fixes pager being moved by nested scroll views. 

When embedding a horizontal scroll view into a (horizontal) pager view dragging on the scroll view can cause pager's scroll view to move. Before the onScroll event wasn't setting destination index in that case which made it report incorrect position.

### Before


https://github.com/user-attachments/assets/898d704d-4ca2-4bcc-8cef-a5796a1a9005

Pay close attention to this progress bar 👆
 
### After

https://github.com/user-attachments/assets/c5f7bb30-4dda-4207-a0a8-61d786e05653


## Test Plan

Check new horizontal scroll example

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
