### PR TITLE
Fix iOS scrollEnabled hardcoded to true

### DIFF
--- a/ios/RNCPagerViewComponentView.mm
+++ b/ios/RNCPagerViewComponentView.mm
@@ -130,7 +130,6 @@ using namespace facebook::react;
     [super prepareForRecycle];
     _nativePageViewController = nil;
     _currentIndex = -1;
-    _scrollEnabled = YES;
 }
 
 - (void)shouldDismissKeyboard:(RNCViewPagerKeyboardDismissMode)dismissKeyboard {
@@ -161,6 +160,8 @@ using namespace facebook::react;
     if (_currentIndex == -1) {
         _currentIndex = newScreenProps.initialPage;
         [self shouldDismissKeyboard: newScreenProps.keyboardDismissMode];
+        _scrollEnabled = newScreenProps.scrollEnabled;
+        [self applyScrollEnabled];
     }
     
     const auto newLayoutDirectionStr = RCTNSStringFromString(toString(newScreenProps.layoutDirection));


### PR DESCRIPTION
# Summary

## Motivation

Fixes a bug where the `scrollEnabled={false}` prop would work correctly on the first render, but on subsequent renders, the scroll would always be enabled even when the prop remained `false`.

## Root Cause

The `prepareForRecycle` method was hardcoding `_scrollEnabled = YES;` when the component was recycled. After recycling, if the prop value didn't change between renders, the `updateProps` method wouldn't update `_scrollEnabled` (because it only updates when the value changes), leaving it with the incorrect hardcoded value.

## Solution

1. **Removed hardcoded reset**: Removed the hardcoded `_scrollEnabled = YES;` reset from the `prepareForRecycle` method (line 133).

2. **Added initialization on first update**: Added `_scrollEnabled` initialization in the `updateProps` method when `_currentIndex == -1` (first update after recycling), ensuring the prop value is always applied correctly on initial mount and after component recycling, even if the prop value hasn't changed from the previous instance.

The changes ensure that:
- The value persists correctly across component recycling
- The prop value is always applied on first update (similar to how `initialPage` is handled)
- `updateProps` properly updates it when the prop value changes

## Areas Impacted

- iOS implementation only (`RNCPagerViewComponentView.mm`)
- Component recycling behavior
- `scrollEnabled` prop handling
- Initial prop application on component mount/recycle

## Test Plan

### Prerequisites
- React Native app with `react-native-pager-view` installed
- iOS device or simulator

### Steps to Reproduce (Before Fix)
1. Create a PagerView component with `scrollEnabled={false}` prop
2. Verify that scrolling is disabled on first render
3. Trigger a re-render (e.g., by updating state)
4. Observe that scrolling becomes enabled despite the prop being `false`

### Verification (After Fix)
1. Set `scrollEnabled={false}` on a PagerView component
2. Verify that scrolling is disabled on first render
3. Trigger multiple re-renders
4. Confirm that scrolling remains disabled across all renders
5. Test component recycling scenarios (unmount/remount) to ensure prop is correctly applied

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅      |
| Android |    ❌      |

*Note: This fix is iOS-specific. Android implementation was not affected by this issue.*

## Checklist

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md` (if needed)
- [ ] I updated the typed files (TS and Flow) (if applicable)