### PR TITLE
fix: overdrag usePagerView

### DIFF
--- a/example/src/component/NavigationPanel/ControlPanel.tsx
+++ b/example/src/component/NavigationPanel/ControlPanel.tsx
@@ -12,7 +12,7 @@ export function ControlsPanel({
   scrollEnabled,
   progress,
   disablePagesAmountManagement,
-  overdragEnabled,
+  overdrag,
   setPage,
   addPage,
   removePage,
@@ -43,7 +43,7 @@ export function ControlsPanel({
         />
         <Button
           style={styles.buttonAdjustment}
-          text={overdragEnabled ? 'Overdrag Enabled' : 'Overdrag Disabled'}
+          text={overdrag ? 'Overdrag Enabled' : 'Overdrag Disabled'}
           onPress={() => toggleOverdrag()}
         />
       </View>

--- a/example/src/hook/useNavigationPanel.ts
+++ b/example/src/hook/useNavigationPanel.ts
@@ -147,7 +147,7 @@ export function useNavigationPanel(
     scrollState,
     scrollEnabled,
     progress,
-    overdragEnabled,
+    overdrag: overdragEnabled,
     setPage,
     addPage,
     removePage,

--- a/src/usePagerView.ts
+++ b/src/usePagerView.ts
@@ -131,7 +131,7 @@ export function usePagerView(
     scrollState,
     scrollEnabled,
     progress,
-    overdragEnabled,
+    overdrag: overdragEnabled,
     setPage,
     addPage,
     removePage,


### PR DESCRIPTION

# Summary

This PR fixes the `overdrag` prop in the hook. 

Pager expects `overdrag` not `overdragEnabled` prop name.