### PR TITLE
fix(android): resolve "Scrapped or attached views may not be recycled" crash

### DIFF
--- a/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt
+++ b/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt
@@ -52,10 +52,9 @@ class ViewPagerAdapter() : Adapter<ViewPagerViewHolder>() {
   }
 
   fun removeAll() {
-    for (index in 1..childrenViews.size) {
-      val child = childrenViews[index-1]
-      if (child.parent?.parent != null) {
-        (child.parent.parent as ViewGroup).removeView(child.parent as View)
+    for (child in childrenViews) {
+      if (child.parent != null) {
+        (child.parent as ViewGroup).removeView(child)
       }
     }
     val removedChildrenCount = childrenViews.size


### PR DESCRIPTION
# Summary

This PR fixes a frequent `java.lang.IllegalArgumentException: Scrapped or attached views may not be recycled` crash on Android.

**Motivation:**
Users have reported crashes in production pointing to [ViewPagerAdapter](cci:2://file:///Users/hv/workspace/react/react-native-pager-view/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt:9:0-70:1), specifically when views are being recycled or removed. This issue has been discussed in #1005.

**The Fix:**
The root cause was identified in the [removeAll](cci:1://file:///Users/hv/workspace/react/react-native-pager-view/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt:53:2-62:3) method of [ViewPagerAdapter.kt](cci:7://file:///Users/hv/workspace/react/react-native-pager-view/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt:0:0-0:0). The previous implementation was manually removing the ViewHolder's container from the `RecyclerView` (accessing it via `child.parent.parent`). This manual manipulation violated the `RecyclerView` contract, causing its internal state ("Recycler") to desynchronize. It would believe a view was still attached or scrapped when it had been forcibly removed, leading to the crash during subsequent layout passes or recycling attempts.

I updated [removeAll](cci:1://file:///Users/hv/workspace/react/react-native-pager-view/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt:53:2-62:3) to safely detach only the React Native child view from its immediate parent (the FrameLayout container). We then rely on `childrenViews.clear()` and `notifyItemRangeRemoved`, allowing `RecyclerView` to handle the removal and recycling of its containers correctly.

**Fixes:** #1005

## Test Plan

I verified this fix by running an app that previously experienced this crash on Android.

### What's required for testing (prerequisites)?
- An Android device or emulator.
- A React Native project using `react-native-pager-view`.

### What are the steps to reproduce (after prerequisites)?
1. Use a [PagerView](cci:2://file:///Users/hv/workspace/react/react-native-pager-view/android/src/main/java/com/reactnativepagerview/ViewPagerViewHolder.kt:8:0-20:1) component.
2. Trigger actions that drastically change the `children` array, specifically clearing the list (calling [removeAll](cci:1://file:///Users/hv/workspace/react/react-native-pager-view/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt:53:2-62:3) internally), while interacting with the pager (swiping).
3. Without the fix, this would often trigger the `IllegalArgumentException`.
4. With the fix, the views are cleared and updated without crashing.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌       |
| Android |    ✅       |

## Checklist

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)