### PR TITLE
fix(ios): guarantee completion block fires and fix swipe permanently disabled after out-of-range goTo (paper arch)

### DIFF
--- a/ios/RNCPagerView.m
+++ b/ios/RNCPagerView.m
@@ -8,6 +8,7 @@
 #import "RCTOnPageScrollStateChanged.h"
 #import "RCTOnPageSelected.h"
 #import <math.h>
+#import "UIPageViewController+SafeSet.h"
 
 @interface RNCPagerView () <UIPageViewControllerDataSource, UIPageViewControllerDelegate, UIScrollViewDelegate>
 
@@ -178,10 +179,10 @@
       [self setTransitioning:YES];
     }
     
-    [self.reactPageViewController setViewControllers:@[controller]
-                                           direction:direction
-                                            animated:animated
-                                          completion:^(BOOL finished) {
+    [self.reactPageViewController safeSetViewControllers:@[controller]
+                                               direction:direction
+                                                animated:animated
+                                              completion:^(BOOL finished) {
         __strong typeof(self) strongSelf = weakSelf;
         strongSelf.currentIndex = index;
         strongSelf.currentView = controller.view;
@@ -257,6 +258,7 @@
     _destinationIndex = index;
     
     if (numberOfPages == 0 || index < 0 || index > numberOfPages - 1) {
+        [self enableSwipe];
         return;
     }
     

--- a/ios/UIPageViewController+SafeSet.h
+++ b/ios/UIPageViewController+SafeSet.h
@@ -1,0 +1,39 @@
+//
+//  UIPageViewController+SafeSet.h
+//
+//  Ensures -setViewControllers:direction:animated:completion: always invokes
+//  its completion block, even when UIKit silently drops it during rapid or
+//  overlapping transitions.
+//
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface UIPageViewController (SafeSet)
+
+/**
+ A safe wrapper around -setViewControllers:direction:animated:completion: that
+ guarantees the completion block is called exactly once.
+
+ When the system completion block is not delivered within a 1-second timeout
+ (a known UIPageViewController quirk during rapid/overlapping transitions),
+ a fallback timer fires the completion block with `finished = NO`.
+ Debounce logic ensures that only the *last* of several rapid calls retains
+ an active timeout, preventing stale completions from interfering with each
+ other.
+
+ @param viewControllers View controllers to display.
+ @param direction       Navigation direction.
+ @param animated        Whether the transition is animated.
+ @param completion      Block invoked exactly once when the transition ends
+                        (or when the timeout expires).
+ */
+- (void)safeSetViewControllers:(nullable NSArray<UIViewController *> *)viewControllers
+                     direction:(UIPageViewControllerNavigationDirection)direction
+                      animated:(BOOL)animated
+                    completion:(void (^ _Nullable)(BOOL finished))completion;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/UIPageViewController+SafeSet.m
+++ b/ios/UIPageViewController+SafeSet.m
@@ -1,0 +1,61 @@
+//
+//  UIPageViewController+SafeSet.m
+//
+
+#import "UIPageViewController+SafeSet.h"
+#import <objc/runtime.h>
+
+@implementation UIPageViewController (SafeSet)
+
+static const void *kSafeSetTimerKey = &kSafeSetTimerKey;
+
+- (void)safeSetViewControllers:(nullable NSArray<UIViewController *> *)viewControllers
+                     direction:(UIPageViewControllerNavigationDirection)direction
+                      animated:(BOOL)animated
+                    completion:(void (^ _Nullable)(BOOL finished))completion {
+    static const NSTimeInterval kSafeSetTimeout = 1.0;
+
+    // Debounce: cancel the pending timeout from a previous rapid call so only
+    // the latest call retains a fallback timer.
+    dispatch_block_t previousTimer = objc_getAssociatedObject(self, kSafeSetTimerKey);
+    if (previousTimer) {
+        dispatch_block_cancel(previousTimer);
+        objc_setAssociatedObject(self, kSafeSetTimerKey, nil, OBJC_ASSOCIATION_RETAIN);
+    }
+
+    // Guard: ensure the completion block is invoked at most once regardless of
+    // whether the system callback or the timeout fires first.
+    __block BOOL hasCompleted = NO;
+    void (^executeCompletion)(BOOL) = ^(BOOL finished) {
+        if (!hasCompleted) {
+            hasCompleted = YES;
+            if (completion) {
+                completion(finished);
+            }
+        }
+    };
+
+    __weak typeof(self) weakSelf = self;
+    dispatch_block_t timer = dispatch_block_create(0, ^{
+        __strong typeof(self) strongSelf = weakSelf;
+        if (!strongSelf) return;
+        // System never called back — fire completion with finished = NO.
+        objc_setAssociatedObject(strongSelf, kSafeSetTimerKey, nil, OBJC_ASSOCIATION_RETAIN);
+        executeCompletion(NO);
+    });
+
+    objc_setAssociatedObject(self, kSafeSetTimerKey, timer, OBJC_ASSOCIATION_RETAIN);
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(kSafeSetTimeout * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(),
+                   timer);
+
+    [self setViewControllers:viewControllers
+                   direction:direction
+                    animated:animated
+                  completion:^(BOOL finished) {
+        dispatch_block_cancel(timer);
+        executeCompletion(finished);
+    }];
+}
+
+@end


### PR DESCRIPTION
## Summary

Two related bugs in the **paper (Old Architecture) iOS implementation** (`ios/RNCPagerView.m`), both causing the pager to become permanently unresponsive to swipe gestures:

### Bug 1 — swipe stuck after an out-of-range `goTo` call

`goTo:` always calls `disableSwipe` before the bounds check, but the early-return path for out-of-range indices never calls `enableSwipe`. If any component (e.g. a parent scroll view or animated list) triggers `goTo:` with an index that is briefly out of range, the pager locks up.

**Fix:** call `[self enableSwipe]` before the early `return`.

### Bug 2 — completion block silently dropped by UIPageViewController

`UIPageViewController -setViewControllers:direction:animated:completion:` is documented to always call its completion block, but in practice it **does not** when:
- the method is called while a previous transition is still in flight, or
- the view controller's view is not yet in the window hierarchy.

When the block is never called, `enableSwipe` is never invoked and `transitioning` stays `YES`, permanently locking the pager.

**Fix:** introduce `UIPageViewController+SafeSet` Objective-C category that wraps the call with:
- a 1-second watchdog timer that fires `completion(NO)` if the system callback never arrives,
- a debounce mechanism so rapid successive calls cancel the previous pending timer, and
- a `hasCompleted` one-shot guard to prevent double-invocation.

## Files changed

| File | Change |
|------|--------|
| `ios/RNCPagerView.m` | Add `enableSwipe` on early return; use `safeSetViewControllers:` |
| `ios/UIPageViewController+SafeSet.h` | New category declaration |
| `ios/UIPageViewController+SafeSet.m` | New category implementation |

## Context

This fix targets the paper-architecture code (`RNCPagerView.m`) which was removed in this repository after v6.8.1. The npm package `react-native-pager-view@6.9.1` (published from git commit `9c8446f`) still contains this code, so there are users in the wild who are affected. I'm submitting this PR to document the fix and to give maintainers the option of issuing a patch release for the v6.x line.

The same `setViewControllers` risk also exists in `ios/Fabric/RNCPagerViewComponentView.mm` (present through v7.x), though that is a separate scope.

## Test plan

- [ ] Navigate to a page index that is temporarily out of range while pages are loading; confirm swipe remains functional afterwards
- [ ] Rapidly call `scrollTo` / `setPage` in quick succession; confirm the pager does not freeze and `onPageSelected` fires for the final destination
- [ ] Verify no double-invocation of `onPageSelected` under normal navigation

🤖 Generated with [Claude Code](https://claude.ai/claude-code)