### PR TITLE
fix(ios): persist position during page list head changes

### DIFF
--- a/ios/PagerViewProvider.swift
+++ b/ios/PagerViewProvider.swift
@@ -74,6 +74,9 @@ import UIKit
       return
     }
     props.children.insert(IdentifiablePlatformView(child), at: index)
+    if index <= props.currentPage {
+      props.currentPage += 1
+    }
   }
 
   @objc(removeChildAtIndex:)
@@ -82,6 +85,9 @@ import UIKit
       return
     }
     props.children.remove(at: index)
+    if index < props.currentPage {
+      props.currentPage -= 1
+    }
   }
 
   override public func didMoveToWindow() {

--- a/ios/PagerViewProvider.swift
+++ b/ios/PagerViewProvider.swift
@@ -73,10 +73,10 @@ import UIKit
     guard index >= 0 && index <= props.children.count else {
       return
     }
-    props.children.insert(IdentifiablePlatformView(child), at: index)
-    if index <= props.currentPage {
+    if index <= props.currentPage && props.currentPage < props.children.count {
       props.currentPage += 1
     }
+    props.children.insert(IdentifiablePlatformView(child), at: index)
   }
 
   @objc(removeChildAtIndex:)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

Dynamic changes to the page list prior to the currently visible page now maintain the same visible page on iOS (this already works on Android).

Fixes #965

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

```ts
function DemoPager() {
  const allPages = [0, 1, 2, 3, 4];
  const [pages, setPages] = useState(allPages);

  const togglePage = (page: number) =>
    setPages((prev) => {
      const itemIndex = prev.indexOf(page);
      const next = [...prev];
      if (itemIndex === -1) {
        next.push(page);
        next.sort((a, b) => a - b);
      } else {
        next.splice(itemIndex, 1);
      }
      return next;
    });

  return (
    <View style={styles.container}>
      <PagerView style={styles.container}>
        {pages.map((page) => (
          <View collapsable={false} key={`x:${page}`}>
            <Text>{page}</Text>
          </View>
        ))}
      </PagerView>
      <View style={styles.container}>
        {allPages.map((page) => (
          <Button
            key={`x:${page}`}
            onPress={() => togglePage(page)}
            title={`Toggle ${page}`}
          />
        ))}
      </View>
    </View>
  );
}

const styles = StyleSheet.create({
  container: {flex: 1},
});
```

### What are the steps to reproduce (after prerequisites)?

Use the above test screen to add/remove pages before/after the currently visible page.  With this PR, iOS should now match the existing Android behavior.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    N/A    |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
