### PR TITLE
fix(ios): use positional index for SwiftUI TabView tags

### DIFF
--- a/ios/PagerView.swift
+++ b/ios/PagerView.swift
@@ -10,11 +10,9 @@ struct PagerView: View {
 
   var body: some View {
     TabView(selection: $props.currentPage) {
-      ForEach(props.children) { child in
-        if let index = props.children.firstIndex(of: child) {
-          RepresentableView(view: child.view)
-            .tag(index)
-        }
+      ForEach(Array(props.children.enumerated()), id: \.element.id) { index, child in
+        RepresentableView(view: child.view)
+          .tag(index)
       }
     }
     .id(props.children.count)


### PR DESCRIPTION
# Summary

Fixes #1079.

In the new SwiftUI `TabView`-based iOS implementation (`ios/PagerView.swift`),
the tag for each page is derived with `props.children.firstIndex(of:)` while
iterating that same array inside `ForEach`:

```swift
ForEach(props.children) { child in
  if let index = props.children.firstIndex(of: child) {
    RepresentableView(view: child.view).tag(index)
  }
}
```

`firstIndex(of:)` returns the index of the **first** `Equatable`-equal element,
so equal entries resolve to the **same** index and produce duplicate `.tag`
values. With `TabView(selection:)`, duplicate tags break page selection — and
**on iOS 17 and below this surfaces as a hard crash
(`NSInternalInconsistencyException`)**. The lookup is also O(n²) over the
`ForEach`.

This PR derives the tag from the positional index via `enumerated()` (unique by
construction) while keeping stable SwiftUI identity through the element `id`:

```swift
ForEach(Array(props.children.enumerated()), id: \.element.id) { index, child in
  RepresentableView(view: child.view).tag(index)
}
```

Impact: iOS new-architecture (Fabric) implementation only. Identity diffing is
unchanged (still keyed by `IdentifiablePlatformView.id`); the change only makes
the tag unique by construction, removing the crash and the O(n²) lookup.

## Test Plan

Verified on a device and a simulator running iOS 17 (and below): **before** this
change, paging throws `NSInternalInconsistencyException` and crashes; **after**
applying the patch the crash is gone and paging works as expected. Behavior is
otherwise unchanged — the positional index matches the previous `firstIndex`
result in normal states.

### What's required for testing (prerequisites)?

- iOS example app on the new architecture (Fabric), running on **iOS 17 or below**.

### What are the steps to reproduce (after prerequisites)?

- Render `<PagerView>` with multiple children and swipe / change pages.
  Before the fix this crashes with `NSInternalInconsistencyException` on iOS ≤ 17;
  after the fix paging works normally.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |     ✅      |
| Android |     ❌      |

## Checklist

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md` <!-- N/A: no API/doc change -->
- [ ] I updated the typed files (TS and Flow) <!-- N/A: native-only change -->
