### PR TITLE
fix(ios): defer SwiftUI host setup until reactViewController is ready

### DIFF
--- a/ios/PagerViewProvider.swift
+++ b/ios/PagerViewProvider.swift
@@ -91,6 +91,13 @@ import UIKit
     }
   }
 
+  override public func layoutSubviews() {
+    super.layoutSubviews()
+    if window != nil {
+      setupView()
+    }
+  }
+
   @objc public func goTo(index: Int, animated: Bool) {
     if animated {
       withAnimation {
@@ -106,19 +113,32 @@ import UIKit
       return
     }
 
-    self.hostingController = UIHostingController(
+    // Only create the hosting controller once it can actually be attached to the
+    // React view-controller hierarchy. `reactViewController()` can be nil on the
+    // first `didMoveToWindow` pass (e.g. when the pager is mounted inside a screen
+    // that is still being attached). Previously `self.hostingController` was
+    // assigned before this check, so when `reactViewController()` was nil the
+    // SwiftUI host was never added/pinned (its view frame stayed `.zero`, leaving
+    // the page blank) while the early-return above prevented any later retry.
+    // Deferring keeps `hostingController` nil so a subsequent window/layout pass
+    // can attach it once the view controller is available.
+    guard let parentViewController = reactViewController() else {
+      return
+    }
+
+    let hostingController = UIHostingController(
       rootView: PagerView(props: props, delegate: delegate),
       ignoreSafeArea: true
     )
-    if let hostingController, let parentViewController = reactViewController() {
-      parentViewController.addChild(hostingController)
-      hostingController.view.backgroundColor = .clear
-      addSubview(hostingController.view)
+    self.hostingController = hostingController
 
-      hostingController.view.translatesAutoresizingMaskIntoConstraints = false
-      hostingController.view.pinEdges(to: self)
+    parentViewController.addChild(hostingController)
+    hostingController.view.backgroundColor = .clear
+    addSubview(hostingController.view)
 
-      hostingController.didMove(toParent: parentViewController)
-    }
+    hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+    hostingController.view.pinEdges(to: self)
+
+    hostingController.didMove(toParent: parentViewController)
   }
 }


### PR DESCRIPTION
Fixes #1089

# Summary

On the New Architecture iOS path, `PagerView` can render a **permanently blank page**, intermittently, with no content visible even though children are mounted with valid frames.

### Root cause

In `PagerViewProvider.setupView()`, `self.hostingController` is assigned **before** verifying that `reactViewController()` is non-nil:

```swift
private func setupView() {
  if self.hostingController != nil {
    return
  }

  self.hostingController = UIHostingController(   // assigned unconditionally
    rootView: PagerView(props: props, delegate: delegate),
    ignoreSafeArea: true
  )
  if let hostingController, let parentViewController = reactViewController() {
    // addChild / addSubview / pinEdges happen only here
  }
}
```

`setupView()` is called from `didMoveToWindow()`. On the first pass `reactViewController()` can still be **nil** (the pager is in a window but its screen/view-controller isn't attached yet). When that happens:

1. The `if let … reactViewController()` block is skipped, so the SwiftUI hosting view is **never added as a subview and never pinned** — its frame stays `.zero`, so the page is blank.
2. `self.hostingController` is now non-nil, so on the **next** `didMoveToWindow()` (when the view controller *is* available) the `if self.hostingController != nil { return }` guard short-circuits and setup **never retries**.

The result is a blank pager for the lifetime of the view. Because it depends on whether `reactViewController()` happens to be ready on the first pass, it reproduces **intermittently** (more often when the pager is mounted during a navigation transition / inside a freshly-pushed screen).

I confirmed this on a device by logging frames: `provider.bounds` was correct (e.g. `{390, 754}`) while `hostingController.view.frame` remained `{0, 0, 0, 0}`, and the failing pass logged `reactViewController() == nil`.

### Implementation

- **Guard before assigning.** `setupView()` now bails out early (leaving `hostingController` nil) when `reactViewController()` is nil, instead of half-initializing. The hosting controller is only created/assigned once it can actually be attached.
- **Retry on layout.** Added a `layoutSubviews()` override that calls `setupView()` while in-window, so attachment happens as soon as the view-controller hierarchy is ready. The existing `hostingController != nil` guard keeps subsequent calls a cheap no-op.

This is a minimal, behavior-preserving change for the happy path (when `reactViewController()` is available on the first pass, behavior is identical).

## Test Plan

### What's required for testing (prerequisites)?

iOS, New Architecture enabled. A `PagerView` mounted inside a screen that is pushed/attached (e.g. behind a navigation transition or tab) so that `reactViewController()` is nil on the first `didMoveToWindow`.

### What are the steps to reproduce (after prerequisites)?

1. Navigate to a screen that renders a `PagerView` as part of its initial mount.
2. Before the fix: the page area is blank (intermittently); switching pages does not help.
3. After the fix: content renders consistently; the host attaches once the view controller becomes available.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |     ✅      |
| Android |     ❌      |

## Checklist

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)

Made with [Cursor](https://cursor.com)