### PR TITLE
fix(android): give ComposeView its own Lifecycle to fix #1103 and #1104

### DIFF
--- a/.maestro/tests/material_top_bar_example.yaml
+++ b/.maestro/tests/material_top_bar_example.yaml
@@ -18,6 +18,34 @@ appId: com.pagerviewexample
 - assertVisible:
     text: 'Tab1'
 
+- tapOn:
+    id: 'material-top-bar-scroll-list-button'
+
+- extendedWaitUntil:
+    visible:
+      id: 'material-top-bar-list-item-30'
+    timeout: 5000
+
+- tapOn:
+    id: 'material-top-bar-open-detail-button'
+
+- extendedWaitUntil:
+    visible:
+      id: 'material-top-bar-detail-screen'
+    timeout: 5000
+
+- pressKey: Back
+
+- extendedWaitUntil:
+    visible:
+      id: 'material-top-bar-tab-1'
+    timeout: 5000
+
+# The existing ComposeView and AndroidView host must survive the native-stack
+# cover/reveal cycle, including the FlatList's native scroll position.
+- assertVisible:
+    id: 'material-top-bar-list-item-30'
+
 - tapOn: 'Tab2'
 
 - extendedWaitUntil:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -246,6 +246,9 @@ dependencies {
   implementation "androidx.compose.foundation:foundation:$compose_version"
   implementation "androidx.compose.runtime:runtime:$compose_version"
   implementation "androidx.compose.ui:ui:$compose_version"
+  // Needed for ComposeViewLifecycleOwner (see ComposePagerView.kt), which
+  // gives the ComposeView a self-owned Lifecycle instead of the ambient one.
+  implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.6.1"
 }
 
 if (isNewArchitectureEnabled()) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -238,6 +238,7 @@ repositories {
 
 def kotlin_version = getExtOrDefault('kotlinVersion')
 def compose_version = getExtOrDefault('composeVersion')
+def lifecycle_version = getExtOrDefault('lifecycleVersion')
 
 dependencies {
     //noinspection GradleDynamicVersion
@@ -248,7 +249,7 @@ dependencies {
   implementation "androidx.compose.ui:ui:$compose_version"
   // Needed for ComposeViewLifecycleOwner (see ComposePagerView.kt), which
   // gives the ComposeView a self-owned Lifecycle instead of the ambient one.
-  implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.6.1"
+  implementation "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycle_version"
 }
 
 if (isNewArchitectureEnabled()) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -250,6 +250,8 @@ dependencies {
   // Needed for ComposeViewLifecycleOwner (see ComposePagerView.kt), which
   // gives the ComposeView a self-owned Lifecycle instead of the ambient one.
   implementation "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycle_version"
+  testImplementation "androidx.arch.core:core-testing:2.2.0"
+  testImplementation "junit:junit:4.13.2"
 }
 
 if (isNewArchitectureEnabled()) {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,5 +1,6 @@
 PagerView_kotlinVersion=2.0.21
 PagerView_composeVersion=1.7.8
+PagerView_lifecycleVersion=2.6.1
 PagerView_minSdkVersion=24
 PagerView_targetSdkVersion=35
 PagerView_compileSdkVersion=35

--- a/android/src/main/java/com/reactnativepagerview/ComposePagerView.kt
+++ b/android/src/main/java/com/reactnativepagerview/ComposePagerView.kt
@@ -24,6 +24,10 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.setViewTreeLifecycleOwner
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.uimanager.UIManagerHelper
 import com.reactnativepagerview.event.PageScrollEvent
@@ -37,7 +41,19 @@ import kotlin.math.sign
 @OptIn(ExperimentalFoundationApi::class)
 class ComposePagerView(context: Context) : FrameLayout(context) {
   private val reactContext = context as ReactContext
-  private val composeView = ComposeView(context)
+  // react-native-screens fully removes and re-adds this screen's Fragment
+  // (rather than merely hiding it) while it's covered by another screen
+  // (see #1103), destroying that Fragment's view-tree Lifecycle. Compose's
+  // default composition-disposal strategies key off that ambient Lifecycle,
+  // so a ComposeView left to use them gets torn down on every cover/reveal
+  // cycle - and rebuilding the composition from scratch each time also
+  // discarded every page's native view host, resetting their state (e.g. a
+  // FlatList's scroll position, see #1104). Giving the ComposeView its own
+  // Lifecycle - one we control instead of the ambient, repeatedly-destroyed
+  // one - lets the composition (and each page's host) survive the cycle
+  // untouched. It only reaches DESTROYED for real in dispose() below.
+  private val composeLifecycleOwner = ComposeViewLifecycleOwner()
+  private var composeView: ComposeView? = null
   private val pages = mutableStateListOf<View>()
   private val scrollEnabledState = mutableStateOf(true)
   private val orientationState = mutableStateOf(Orientation.Horizontal)
@@ -57,43 +73,57 @@ class ComposePagerView(context: Context) : FrameLayout(context) {
   private val scrollCommandState = mutableStateOf<ScrollCommand?>(null)
   private var lastEmittedScrollState: String? = null
   private var lastEmittedPageSelected: Int? = null
-  private var didSetContent = false
 
   init {
     id = View.generateViewId()
     layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
     isSaveEnabled = false
-
-    composeView.layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
-    composeView.isSaveEnabled = false
-    composeView.setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindow)
     applyOverScrollMode()
     touchSlop = ViewConfiguration.get(context).scaledTouchSlop
   }
 
+  private fun createComposeView(): ComposeView {
+    return ComposeView(context).apply {
+      layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
+      isSaveEnabled = false
+      layoutDirection = androidLayoutDirection()
+      overScrollMode = androidOverScrollMode()
+      // Bind our own Lifecycle before the composition is created, so Compose
+      // resolves it instead of walking up to the ambient (and repeatedly
+      // destroyed) Fragment view-tree Lifecycle - see the field comment above.
+      setViewTreeLifecycleOwner(composeLifecycleOwner)
+      setViewCompositionStrategy(
+        ViewCompositionStrategy.DisposeOnLifecycleDestroyed(composeLifecycleOwner)
+      )
+    }
+  }
+
   override fun onAttachedToWindow() {
     super.onAttachedToWindow()
-    if (composeView.parent == null) {
-      super.addView(composeView)
-      post {
-        measureAndLayoutComposeView()
-      }
-    }
-    if (!didSetContent) {
-      didSetContent = true
-      composeView.setContent {
+    if (composeView == null) {
+      val view = createComposeView()
+      composeView = view
+      super.addView(view)
+      view.setContent {
         PagerContent()
       }
+    }
+    post {
+      measureAndLayoutComposeView()
     }
   }
 
   override fun onDetachedFromWindow() {
     updateSameOrientationAncestorsGestureState(false)
-    if (composeView.parent === this) {
-      super.removeView(composeView)
-      didSetContent = false
-    }
+    // composeView is intentionally left attached and alive here: its
+    // Lifecycle is self-owned (see composeLifecycleOwner) and only reaches
+    // DESTROYED in dispose(), so there is nothing to tear down on a mere
+    // window detach.
     super.onDetachedFromWindow()
+  }
+
+  fun dispose() {
+    composeLifecycleOwner.destroy()
   }
 
   override fun dispatchTouchEvent(event: MotionEvent): Boolean {
@@ -149,7 +179,7 @@ class ComposePagerView(context: Context) : FrameLayout(context) {
     val width = width.takeIf { it > 0 } ?: measuredWidth
     val height = height.takeIf { it > 0 } ?: measuredHeight
     if (measureComposeView(width, height)) {
-      composeView.layout(0, 0, width, height)
+      composeView?.layout(0, 0, width, height)
     }
   }
 
@@ -157,11 +187,12 @@ class ComposePagerView(context: Context) : FrameLayout(context) {
     width: Int = measuredWidth,
     height: Int = measuredHeight
   ): Boolean {
-    if (composeView.parent !== this || width <= 0 || height <= 0) {
+    val view = composeView
+    if (view == null || view.parent !== this || width <= 0 || height <= 0) {
       return false
     }
 
-    composeView.measure(
+    view.measure(
       MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
       MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY)
     )
@@ -238,13 +269,16 @@ class ComposePagerView(context: Context) : FrameLayout(context) {
 
   fun setLayoutDirection(value: String) {
     layoutDirectionState.value = if (value == "rtl") LayoutDirection.Rtl else LayoutDirection.Ltr
-    val androidLayoutDirection = if (layoutDirectionState.value == LayoutDirection.Rtl) {
+    layoutDirection = androidLayoutDirection()
+    composeView?.layoutDirection = androidLayoutDirection()
+  }
+
+  private fun androidLayoutDirection(): Int {
+    return if (layoutDirectionState.value == LayoutDirection.Rtl) {
       View.LAYOUT_DIRECTION_RTL
     } else {
       View.LAYOUT_DIRECTION_LTR
     }
-    layoutDirection = androidLayoutDirection
-    composeView.layoutDirection = androidLayoutDirection
   }
 
   fun setOffscreenPageLimit(value: Int) {
@@ -265,13 +299,17 @@ class ComposePagerView(context: Context) : FrameLayout(context) {
   }
 
   private fun applyOverScrollMode() {
-    val androidOverScrollMode = when (overScrollModeState.value) {
+    val androidOverScrollMode = androidOverScrollMode()
+    overScrollMode = androidOverScrollMode
+    composeView?.overScrollMode = androidOverScrollMode
+  }
+
+  private fun androidOverScrollMode(): Int {
+    return when (overScrollModeState.value) {
       OverScrollMode.Never -> View.OVER_SCROLL_NEVER
       OverScrollMode.Always -> View.OVER_SCROLL_ALWAYS
       OverScrollMode.Auto -> View.OVER_SCROLL_IF_CONTENT_SCROLLS
     }
-    overScrollMode = androidOverScrollMode
-    composeView.overScrollMode = androidOverScrollMode
   }
 
   private fun setSameOrientationChildGestureActive(value: Boolean) {
@@ -604,5 +642,23 @@ class ComposePagerView(context: Context) : FrameLayout(context) {
     } else {
       offscreenPageLimitState.value.coerceAtLeast(0)
     }
+  }
+}
+
+// A Lifecycle that isn't derived from the ambient Fragment/Activity: it
+// starts RESUMED and only moves to DESTROYED when destroy() is called
+// explicitly, so it survives being covered/revealed by react-native-screens'
+// Fragment remove+re-add (see the composeLifecycleOwner field comment on
+// ComposePagerView above).
+private class ComposeViewLifecycleOwner : LifecycleOwner {
+  private val registry = LifecycleRegistry(this).apply {
+    currentState = Lifecycle.State.RESUMED
+  }
+
+  override val lifecycle: Lifecycle
+    get() = registry
+
+  fun destroy() {
+    registry.currentState = Lifecycle.State.DESTROYED
   }
 }

--- a/android/src/main/java/com/reactnativepagerview/ComposePagerView.kt
+++ b/android/src/main/java/com/reactnativepagerview/ComposePagerView.kt
@@ -100,6 +100,7 @@ class ComposePagerView(context: Context) : FrameLayout(context) {
 
   override fun onAttachedToWindow() {
     super.onAttachedToWindow()
+    composeLifecycleOwner.resume()
     if (composeView == null) {
       val view = createComposeView()
       composeView = view
@@ -117,8 +118,12 @@ class ComposePagerView(context: Context) : FrameLayout(context) {
     updateSameOrientationAncestorsGestureState(false)
     // composeView is intentionally left attached and alive here: its
     // Lifecycle is self-owned (see composeLifecycleOwner) and only reaches
-    // DESTROYED in dispose(), so there is nothing to tear down on a mere
-    // window detach.
+    // DESTROYED in dispose(). We pause it to CREATED instead, so lifecycle-
+    // aware content within pages (video players, nested Compose effects,
+    // screen-view tracking) stops doing work while covered - this doesn't
+    // dispose the composition, since DisposeOnLifecycleDestroyed only acts
+    // on ON_DESTROY.
+    composeLifecycleOwner.pause()
     super.onDetachedFromWindow()
   }
 
@@ -657,6 +662,18 @@ private class ComposeViewLifecycleOwner : LifecycleOwner {
 
   override val lifecycle: Lifecycle
     get() = registry
+
+  fun resume() {
+    if (registry.currentState != Lifecycle.State.DESTROYED) {
+      registry.currentState = Lifecycle.State.RESUMED
+    }
+  }
+
+  fun pause() {
+    if (registry.currentState != Lifecycle.State.DESTROYED) {
+      registry.currentState = Lifecycle.State.CREATED
+    }
+  }
 
   fun destroy() {
     registry.currentState = Lifecycle.State.DESTROYED

--- a/android/src/main/java/com/reactnativepagerview/ComposePagerView.kt
+++ b/android/src/main/java/com/reactnativepagerview/ComposePagerView.kt
@@ -25,8 +25,10 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.setViewTreeLifecycleOwner
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.uimanager.UIManagerHelper
@@ -100,7 +102,11 @@ class ComposePagerView(context: Context) : FrameLayout(context) {
 
   override fun onAttachedToWindow() {
     super.onAttachedToWindow()
-    composeLifecycleOwner.resume()
+    // Read the ambient owner from our parent before installing the stable
+    // owner on the ComposeView below. This keeps the composition alive across
+    // Fragment view-tree replacement while still following pause/stop events
+    // from the currently active host.
+    composeLifecycleOwner.attach(findViewTreeLifecycleOwner()?.lifecycle)
     if (composeView == null) {
       val view = createComposeView()
       composeView = view
@@ -123,7 +129,7 @@ class ComposePagerView(context: Context) : FrameLayout(context) {
     // screen-view tracking) stops doing work while covered - this doesn't
     // dispose the composition, since DisposeOnLifecycleDestroyed only acts
     // on ON_DESTROY.
-    composeLifecycleOwner.pause()
+    composeLifecycleOwner.detach()
     super.onDetachedFromWindow()
   }
 
@@ -650,32 +656,88 @@ class ComposePagerView(context: Context) : FrameLayout(context) {
   }
 }
 
-// A Lifecycle that isn't derived from the ambient Fragment/Activity: it
-// starts RESUMED and only moves to DESTROYED when destroy() is called
-// explicitly, so it survives being covered/revealed by react-native-screens'
-// Fragment remove+re-add (see the composeLifecycleOwner field comment on
-// ComposePagerView above).
-private class ComposeViewLifecycleOwner : LifecycleOwner {
+// A stable Lifecycle that follows the currently attached host through
+// CREATED/STARTED/RESUMED, but only moves to DESTROYED when destroy() is
+// called explicitly. This lets it survive react-native-screens replacing the
+// ambient Fragment view-tree owner (see the field comment above).
+internal class ComposeViewLifecycleOwner : LifecycleOwner, LifecycleEventObserver {
   private val registry = LifecycleRegistry(this).apply {
-    currentState = Lifecycle.State.RESUMED
+    currentState = Lifecycle.State.CREATED
   }
+  private var hostLifecycle: Lifecycle? = null
+  private var isAttached = false
+  private var isDestroyed = false
 
   override val lifecycle: Lifecycle
     get() = registry
 
-  fun resume() {
-    if (registry.currentState != Lifecycle.State.DESTROYED) {
-      registry.currentState = Lifecycle.State.RESUMED
+  fun attach(lifecycle: Lifecycle?) {
+    if (isDestroyed) {
+      return
     }
+
+    isAttached = true
+    setHostLifecycle(lifecycle)
+    updateState()
   }
 
-  fun pause() {
-    if (registry.currentState != Lifecycle.State.DESTROYED) {
-      registry.currentState = Lifecycle.State.CREATED
+  fun detach() {
+    if (isDestroyed) {
+      return
     }
+
+    isAttached = false
+    setHostLifecycle(null)
+    updateState()
   }
 
   fun destroy() {
+    if (isDestroyed) {
+      return
+    }
+
+    isDestroyed = true
+    isAttached = false
+    setHostLifecycle(null)
     registry.currentState = Lifecycle.State.DESTROYED
+  }
+
+  override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
+    if (event == Lifecycle.Event.ON_DESTROY && source.lifecycle === hostLifecycle) {
+      setHostLifecycle(null)
+    }
+    updateState()
+  }
+
+  private fun setHostLifecycle(lifecycle: Lifecycle?) {
+    if (hostLifecycle === lifecycle) {
+      return
+    }
+
+    hostLifecycle?.removeObserver(this)
+    hostLifecycle = lifecycle
+    lifecycle?.addObserver(this)
+  }
+
+  private fun updateState() {
+    if (isDestroyed) {
+      return
+    }
+
+    registry.currentState = if (!isAttached) {
+      Lifecycle.State.CREATED
+    } else {
+      when (hostLifecycle?.currentState) {
+        Lifecycle.State.RESUMED -> Lifecycle.State.RESUMED
+        Lifecycle.State.STARTED -> Lifecycle.State.STARTED
+        // INITIALIZED is expected briefly when react-native-screens installs
+        // a replacement Fragment view tree. DESTROYED belongs to the old
+        // tree. Neither should destroy or block the retained composition.
+        Lifecycle.State.INITIALIZED,
+        Lifecycle.State.CREATED,
+        Lifecycle.State.DESTROYED,
+        null -> Lifecycle.State.CREATED
+      }
+    }
   }
 }

--- a/android/src/main/java/com/reactnativepagerview/PagerViewViewManager.kt
+++ b/android/src/main/java/com/reactnativepagerview/PagerViewViewManager.kt
@@ -69,6 +69,11 @@ class PagerViewViewManager : ViewGroupManager<ComposePagerView>(), RNCViewPagerM
         return true
     }
 
+    override fun onDropViewInstance(view: ComposePagerView) {
+        view.dispose()
+        super.onDropViewInstance(view)
+    }
+
     @ReactProp(name = "scrollEnabled", defaultBoolean = true)
     override fun setScrollEnabled(view: ComposePagerView?, value: Boolean) {
         if (view != null) {

--- a/android/src/test/java/com/reactnativepagerview/ComposeViewLifecycleOwnerTest.kt
+++ b/android/src/test/java/com/reactnativepagerview/ComposeViewLifecycleOwnerTest.kt
@@ -1,0 +1,86 @@
+package com.reactnativepagerview
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+class ComposeViewLifecycleOwnerTest {
+  @get:Rule
+  val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+  @Test
+  fun `follows the attached host lifecycle without inheriting destruction`() {
+    val owner = ComposeViewLifecycleOwner()
+    val host = TestLifecycleOwner()
+
+    host.moveTo(Lifecycle.State.RESUMED)
+    owner.attach(host.lifecycle)
+    assertEquals(Lifecycle.State.RESUMED, owner.lifecycle.currentState)
+
+    host.moveTo(Lifecycle.State.STARTED)
+    assertEquals(Lifecycle.State.STARTED, owner.lifecycle.currentState)
+
+    host.moveTo(Lifecycle.State.CREATED)
+    assertEquals(Lifecycle.State.CREATED, owner.lifecycle.currentState)
+
+    host.moveTo(Lifecycle.State.RESUMED)
+    assertEquals(Lifecycle.State.RESUMED, owner.lifecycle.currentState)
+
+    host.moveTo(Lifecycle.State.DESTROYED)
+    assertEquals(Lifecycle.State.CREATED, owner.lifecycle.currentState)
+  }
+
+  @Test
+  fun `survives host replacement and follows the replacement owner`() {
+    val owner = ComposeViewLifecycleOwner()
+    val oldHost = TestLifecycleOwner()
+    val replacementHost = TestLifecycleOwner()
+
+    oldHost.moveTo(Lifecycle.State.RESUMED)
+    owner.attach(oldHost.lifecycle)
+    oldHost.moveTo(Lifecycle.State.DESTROYED)
+
+    owner.detach()
+    owner.attach(replacementHost.lifecycle)
+    assertEquals(Lifecycle.State.CREATED, owner.lifecycle.currentState)
+
+    replacementHost.moveTo(Lifecycle.State.STARTED)
+    assertEquals(Lifecycle.State.STARTED, owner.lifecycle.currentState)
+
+    replacementHost.moveTo(Lifecycle.State.RESUMED)
+    assertEquals(Lifecycle.State.RESUMED, owner.lifecycle.currentState)
+  }
+
+  @Test
+  fun `detaches from the host and only destroys on explicit disposal`() {
+    val owner = ComposeViewLifecycleOwner()
+    val host = TestLifecycleOwner()
+
+    host.moveTo(Lifecycle.State.RESUMED)
+    owner.attach(host.lifecycle)
+    owner.detach()
+    assertEquals(Lifecycle.State.CREATED, owner.lifecycle.currentState)
+
+    host.moveTo(Lifecycle.State.CREATED)
+    host.moveTo(Lifecycle.State.RESUMED)
+    assertEquals(Lifecycle.State.CREATED, owner.lifecycle.currentState)
+
+    owner.destroy()
+    assertEquals(Lifecycle.State.DESTROYED, owner.lifecycle.currentState)
+  }
+
+  private class TestLifecycleOwner : LifecycleOwner {
+    private val registry = LifecycleRegistry(this)
+
+    override val lifecycle: Lifecycle
+      get() = registry
+
+    fun moveTo(state: Lifecycle.State) {
+      registry.currentState = state
+    }
+  }
+}

--- a/example/src/MaterialTopTabExample.tsx
+++ b/example/src/MaterialTopTabExample.tsx
@@ -2,15 +2,37 @@ import React, { useState } from 'react';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs';
 
-import { View, Text, Button } from 'react-native';
+import { View, Text, Button, FlatList, StyleSheet } from 'react-native';
 
-function Tab1() {
+const listItems = Array.from({ length: 50 }, (_, index) => `List item ${index}`);
+
+function Tab1(props: { onOpenDetail: () => void }) {
+  const listRef = React.useRef<FlatList<string>>(null);
+
   return (
-    <View
-      testID="material-top-bar-tab-1"
-      style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}
-    >
+    <View testID="material-top-bar-tab-1" style={styles.tab}>
       <Text testID="material-top-bar-tab-1-text">Tab 1</Text>
+      <Button
+        testID="material-top-bar-scroll-list-button"
+        title="Scroll list"
+        onPress={() => listRef.current?.scrollToIndex({ index: 30 })}
+      />
+      <Button
+        testID="material-top-bar-open-detail-button"
+        title="Open detail"
+        onPress={props.onOpenDetail}
+      />
+      <FlatList
+        ref={listRef}
+        testID="material-top-bar-list"
+        data={listItems}
+        keyExtractor={(item) => item}
+        renderItem={({ item, index }) => (
+          <Text testID={`material-top-bar-list-item-${index}`} style={styles.row}>
+            {item}
+          </Text>
+        )}
+      />
     </View>
   );
 }
@@ -56,7 +78,9 @@ const PostAuthScreen = (props: any) => {
   return (
     <View testID="material-top-bar-post-auth-screen" style={{ flex: 1 }}>
       <Navigator>
-        <Screen name="Tab1" component={Tab1} />
+        <Screen name="Tab1">
+          {() => <Tab1 onOpenDetail={props.onOpenDetail} />}
+        </Screen>
         <Screen name="Tab2">
           {(props: any) => <Tab2 {...props} onLogout={onLogout} />}
         </Screen>
@@ -64,6 +88,12 @@ const PostAuthScreen = (props: any) => {
     </View>
   );
 };
+
+const DetailScreen = () => (
+  <View testID="material-top-bar-detail-screen" style={styles.centered}>
+    <Text>Detail screen</Text>
+  </View>
+);
 
 export function MaterialTopBarExample() {
   const { Screen, Navigator } = createNativeStackNavigator();
@@ -80,10 +110,30 @@ export function MaterialTopBarExample() {
       ) : (
         <Screen name="Post Auth Screen">
           {(props: any) => (
-            <PostAuthScreen {...props} setIsSignedIn={setIsSignedIn} />
+            <PostAuthScreen
+              {...props}
+              setIsSignedIn={setIsSignedIn}
+              onOpenDetail={() => props.navigation.navigate('Detail Screen')}
+            />
           )}
         </Screen>
       )}
+      <Screen name="Detail Screen" component={DetailScreen} />
     </Navigator>
   );
 }
+
+const styles = StyleSheet.create({
+  tab: {
+    flex: 1,
+  },
+  centered: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  row: {
+    height: 48,
+    padding: 12,
+  },
+});


### PR DESCRIPTION
## Summary
- react-native-screens fully removes and re-adds a covered screen's Fragment instead of just hiding it, destroying that Fragment's view-tree Lifecycle.
- Compose's default disposal strategy keys off that ambient Lifecycle, so the pager's `ComposeView` was torn down and rebuilt on every cover/reveal cycle: this caused a blank pager after covering the screen (#1103) and reset each page's native view state, e.g. FlatList scroll position (#1104).
- Giving the `ComposeView` its own self-owned `Lifecycle` (only destroyed for real in `onDropViewInstance`) lets the composition and each page's host survive the cover/reveal cycle untouched.

Fixes #1103
Fixes #1104

## Test plan
- [x] Manually verified with a `react-navigation` material-top-tabs stack that covering/revealing a screen containing the pager no longer blanks it out.
- [x] Manually verified a FlatList page inside the pager keeps its scroll position after the screen is covered and revealed again.